### PR TITLE
Finish select functionality

### DIFF
--- a/Xcodes/Backend/Environment.swift
+++ b/Xcodes/Backend/Environment.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import PromiseKit
 import PMKFoundation
@@ -50,11 +51,7 @@ public struct Shell {
         authenticateSudoerIfNecessary(passwordInput)
     }
 
-    public var xcodeSelectPrintPath: () -> Promise<ProcessOutput> = { Process.run(Path.root.usr.bin.join("xcode-select"), "-p") }
-    public var xcodeSelectSwitch: (String?, String) -> Promise<ProcessOutput> = { Process.sudo(password: $0, Path.root.usr.bin.join("xcode-select"), "-s", $1) }
-    public func xcodeSelectSwitch(password: String?, path: String) -> Promise<ProcessOutput> {
-        xcodeSelectSwitch(password, path)
-    }
+    public var xcodeSelectPrintPath: () -> AnyPublisher<ProcessOutput, Error> = { Process.run(Path.root.usr.bin.join("xcode-select"), "-p") }
 }
 
 public struct Files {

--- a/Xcodes/Backend/Process.swift
+++ b/Xcodes/Backend/Process.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import PromiseKit
 import PMKFoundation
@@ -37,5 +38,48 @@ extension Process {
             let error = String(data: std.err.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
             return (process.terminationStatus, output, error)
         }
+    }
+    
+    @discardableResult
+    static func run(_ executable: Path, workingDirectory: URL? = nil, input: String? = nil, _ arguments: String...) -> AnyPublisher<ProcessOutput, Error> {
+        return run(executable.url, workingDirectory: workingDirectory, input: input, arguments)
+    }
+    
+    @discardableResult
+    static func run(_ executable: URL, workingDirectory: URL? = nil, input: String? = nil, _ arguments: [String]) -> AnyPublisher<ProcessOutput, Error> {
+        Deferred {
+            Future<ProcessOutput, Error> { promise in
+                let process = Process()
+                process.currentDirectoryURL = workingDirectory ?? executable.deletingLastPathComponent()
+                process.executableURL = executable
+                process.arguments = arguments
+                
+                let (stdout, stderr) = (Pipe(), Pipe())
+                process.standardOutput = stdout
+                process.standardError = stderr
+                
+                if let input = input {
+                    let inputPipe = Pipe()
+                    process.standardInput = inputPipe.fileHandleForReading
+                    inputPipe.fileHandleForWriting.write(Data(input.utf8))
+                    inputPipe.fileHandleForWriting.closeFile()
+                }
+                
+                do {
+                    try process.run()
+                    process.waitUntilExit()
+
+                    let output = String(data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+                    let error = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+                
+                    promise(.success((process.terminationStatus, output, error)))
+                } catch {
+                    promise(.failure(error))
+                }
+            }
+        }
+        .subscribe(on: DispatchQueue.global())
+        .receive(on: DispatchQueue.main)
+        .eraseToAnyPublisher()
     }
 }

--- a/Xcodes/Backend/XcodeCommands.swift
+++ b/Xcodes/Backend/XcodeCommands.swift
@@ -58,6 +58,7 @@ struct SelectButton: View {
         Button(action: select) {
             Text("Select")
         }
+        .disabled(xcode?.selected != false)
     }
     
     private func select() {

--- a/Xcodes/Frontend/XcodeList/XcodeListView.swift
+++ b/Xcodes/Frontend/XcodeList/XcodeListView.swift
@@ -42,12 +42,13 @@ struct XcodeListView: View {
                         .foregroundColor(appState.selectedXcodeID == xcode.id ? Color(NSColor.selectedMenuItemTextColor) : Color(NSColor.secondaryLabelColor))
                 }
                 
+                
+                Spacer()
+                
                 if xcode.selected {
                     Tag(text: "SELECTED")
                         .foregroundColor(.green)
                 }
-                
-                Spacer()
                 
                 Button(xcode.installed ? "INSTALLED" : "INSTALL") {
                     print("Installing...")
@@ -90,10 +91,10 @@ struct XcodeListView_Previews: PreviewProvider {
                 .environmentObject({ () -> AppState in
                     let a = AppState()
                     a.allXcodes = [
-                        Xcode(version: Version("12.3.0")!, installState: .installed, selected: true, path: nil, icon: nil),
+                        Xcode(version: Version("12.3.0")!, installState: .installed, selected: true, path: "/Applications/Xcode-12.3.0.app", icon: nil),
                         Xcode(version: Version("12.2.0")!, installState: .notInstalled, selected: false, path: nil, icon: nil),
                         Xcode(version: Version("12.1.0")!, installState: .notInstalled, selected: false, path: nil, icon: nil),
-                        Xcode(version: Version("12.0.0")!, installState: .installed, selected: false, path: nil, icon: nil),
+                        Xcode(version: Version("12.0.0")!, installState: .installed, selected: false, path: "/Applications/Xcode-12.3.0.app", icon: nil),
                     ]
                     return a
                 }())


### PR DESCRIPTION
This finishes up the select functionality by getting the currently selected path from xcode-select and making sure it's reflected in the UI. This uses a Tag in the main list, and enables/disables all of the controls that can change it: menu bar menu item, context menu item, inspector button.

![Screen Shot 2020-12-28 at 12 50 06 PM](https://user-images.githubusercontent.com/594059/103239733-b54b2200-490b-11eb-995e-6f9a00854bb8.png)

Closes #6 