### PR TITLE
Fixes acknowledgment screen in darkmode

### DIFF
--- a/Xcodes/Frontend/About/AcknowledgementsView.swift
+++ b/Xcodes/Frontend/About/AcknowledgementsView.swift
@@ -1,12 +1,14 @@
 import SwiftUI
 
 struct AcknowledgmentsView: View {
+    
     var body: some View {
         ScrollingTextView(
             attributedString: NSAttributedString(
                 rtf: try! Data(contentsOf: Bundle.main.url(forResource: "Licenses", withExtension: "rtf")!), 
                 documentAttributes: nil
             )!
+            .addingAttribute(.foregroundColor, value: NSColor.labelColor)
         )
         .frame(minWidth: 500, minHeight: 500)
     }


### PR DESCRIPTION
Acknowledgement View in dark mode wasn't using an appropriate color

![image](https://user-images.githubusercontent.com/1119565/103382770-d2235900-4ab5-11eb-912a-e581d9ff8591.png)

Switched to using label color
![image](https://user-images.githubusercontent.com/1119565/103382809-f41cdb80-4ab5-11eb-9047-d3d1c2ac648e.png)


