### PR TITLE
Set skip install to YES for helper

### DIFF
--- a/Xcodes.xcodeproj/project.pbxproj
+++ b/Xcodes.xcodeproj/project.pbxproj
@@ -853,6 +853,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.robotsandpencils.XcodesApp.Helper;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "com.robotsandpencils.XcodesApp.Helper/com.robotsandpencils.XcodesApp.Helper-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 			};
@@ -877,6 +878,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.robotsandpencils.XcodesApp.Helper;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "com.robotsandpencils.XcodesApp.Helper/com.robotsandpencils.XcodesApp.Helper-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 			};
@@ -899,6 +901,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.robotsandpencils.XcodesApp.Helper;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "com.robotsandpencils.XcodesApp.Helper/com.robotsandpencils.XcodesApp.Helper-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 			};


### PR DESCRIPTION
The helper is already bundled in a specific location in the app, and so we don't need it to also be added to archives that we make, independent of the app. Having two build products in the archive makes it a "generic Xcode archive" and we can't distribute it (developer ID sign and notarize.) This change fixes that.

This also serves as confirmation that universal binaries are created, closing #28.

![Screen Shot 2021-01-01 at 9 17 13 PM](https://user-images.githubusercontent.com/594059/103450728-8ae4c600-4c77-11eb-8b2e-4ab7fe140fe4.png)
