### PR TITLE
Only run CI workflow on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,11 @@
 name: CI
-on: [push, pull_request]
+
+on:
+  push:
+    branches: 
+      - main
+  pull_request:
+
 jobs:
   test:
     runs-on: macOS-11.0


### PR DESCRIPTION
The pull request event should handle running it on other branches, assuming that they're at least submitted as draft PRs. Right now this is running twice (once for each event) on PR branches which is unnecessary.