### PR TITLE
Stop aria2c if Xcodes stops

### DIFF
--- a/Xcodes/Backend/Environment.swift
+++ b/Xcodes/Backend/Environment.swift
@@ -43,6 +43,7 @@ public struct Shell {
             "--max-connection-per-server=16",
             "--split=16",
             "--summary-interval=1",
+            "--stop-with-process=\(ProcessInfo.processInfo.processIdentifier)",
             "--dir=\(destination.parent.string)",
             "--out=\(destination.basename())",
             url.absoluteString,


### PR DESCRIPTION
I removed this when I brought the code over from `xcodes` because I thought it wasn't necessary for some reason. We do send a SIGTERM if the user cancels the installation (via subscription cancellation), but if the whole app quits aria2c would keep running in the background.

Testing:

- Run Xcodes
- Install something
- Stop Xcodes (stop running in Xcode or quit)
- Open Activity Monitor and make sure `aria2c` isn't still running