### PR TITLE
Replace print/dump/NSLog with os.log Logger

### DIFF
--- a/Xcodes.xcodeproj/project.pbxproj
+++ b/Xcodes.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		CA25192A25A9644800F08414 /* XcodeInstallState.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA25192925A9644800F08414 /* XcodeInstallState.swift */; };
 		CA378F992466567600A58CE0 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA378F982466567600A58CE0 /* AppState.swift */; };
 		CA39711924495F0E00AFFB77 /* AppStoreButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA39711824495F0E00AFFB77 /* AppStoreButtonStyle.swift */; };
+		CA42DD6E25AEA8B200BC0B0C /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA42DD6D25AEA8B200BC0B0C /* Logger.swift */; };
+		CA42DD7325AEB04300BC0B0C /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA42DD7225AEB04300BC0B0C /* Logger.swift */; };
 		CA44901F2463AD34003D8213 /* Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA44901E2463AD34003D8213 /* Tag.swift */; };
 		CA452BB0259FD9770072DFA4 /* ProgressIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA452BAF259FD9770072DFA4 /* ProgressIndicator.swift */; };
 		CA452BC1259FDDFE0072DFA4 /* Stub-version.plist in Resources */ = {isa = PBXBuildFile; fileRef = CA452BBF259FDDFE0072DFA4 /* Stub-version.plist */; };
@@ -153,6 +155,8 @@
 		CA25192925A9644800F08414 /* XcodeInstallState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcodeInstallState.swift; sourceTree = "<group>"; };
 		CA378F982466567600A58CE0 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		CA39711824495F0E00AFFB77 /* AppStoreButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStoreButtonStyle.swift; sourceTree = "<group>"; };
+		CA42DD6D25AEA8B200BC0B0C /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
+		CA42DD7225AEB04300BC0B0C /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		CA44901E2463AD34003D8213 /* Tag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tag.swift; sourceTree = "<group>"; };
 		CA452BAF259FD9770072DFA4 /* ProgressIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressIndicator.swift; sourceTree = "<group>"; };
 		CA452BBF259FDDFE0072DFA4 /* Stub-version.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Stub-version.plist"; sourceTree = "<group>"; };
@@ -337,6 +341,7 @@
 				CA9FF8E525959BB800E47BAF /* AuditTokenHack.m */,
 				CA9FF8EA25959BDD00E47BAF /* com.robotsandpencils.XcodesApp.Helper-Bridging-Header.h */,
 				CA9FF8DF25959BAA00E47BAF /* ConnectionVerifier.swift */,
+				CA42DD7225AEB04300BC0B0C /* Logger.swift */,
 				CA9FF8B02595967A00E47BAF /* main.swift */,
 				CA9FF8DA25959B4000E47BAF /* XPCDelegate.swift */,
 				CA9FF8C22595988B00E47BAF /* Info.plist */,
@@ -409,6 +414,7 @@
 				CAC281D9259F985100B8AB0B /* InstallationStep.swift */,
 				CA9FF8862595607900E47BAF /* InstalledXcode.swift */,
 				CAA8587B25A2B37900ACF8C0 /* IsTesting.swift */,
+				CA42DD6D25AEA8B200BC0B0C /* Logger.swift */,
 				CAE4248B259A68B800B8B246 /* Optional+IsNotNil.swift */,
 				CABFA9AE2592EEE900380FEE /* Path+.swift */,
 				CABFA9B42592EEEA00380FEE /* Process.swift */,
@@ -698,6 +704,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CA9FF8D025959A9700E47BAF /* HelperXPCShared.swift in Sources */,
+				CA42DD7325AEB04300BC0B0C /* Logger.swift in Sources */,
 				CA9FF8DB25959B4000E47BAF /* XPCDelegate.swift in Sources */,
 				CA9FF8E625959BB800E47BAF /* AuditTokenHack.m in Sources */,
 				CA9FF8B12595967A00E47BAF /* main.swift in Sources */,
@@ -732,6 +739,7 @@
 				CABFA9C52592EEEA00380FEE /* FileManager+.swift in Sources */,
 				CABFA9CD2592EEEA00380FEE /* Foundation.swift in Sources */,
 				CA9FF8872595607900E47BAF /* InstalledXcode.swift in Sources */,
+				CA42DD6E25AEA8B200BC0B0C /* Logger.swift in Sources */,
 				CA61A6E0259835580008926E /* Xcode.swift in Sources */,
 				CAE4247F259A666100B8B246 /* MainWindow.swift in Sources */,
 				CA452BB0259FD9770072DFA4 /* ProgressIndicator.swift in Sources */,

--- a/Xcodes/AppleAPI/Sources/AppleAPI/Environment.swift
+++ b/Xcodes/AppleAPI/Sources/AppleAPI/Environment.swift
@@ -10,7 +10,6 @@ import Combine
  */
 public struct Environment {
     public var network = Network()
-    public var logging = Logging()
 }
 
 public var Current = Environment()
@@ -22,8 +21,4 @@ public struct Network {
     public func dataTask(with request: URLRequest) -> URLSession.DataTaskPublisher {
         dataTask(request)
     }
-}
-
-public struct Logging {
-    public var log: (String) -> Void = { print($0) }
 }

--- a/Xcodes/Backend/AppState+Install.swift
+++ b/Xcodes/Backend/AppState+Install.swift
@@ -4,6 +4,7 @@ import Path
 import AppleAPI
 import Version
 import LegibleError
+import os.log
 
 /// Downloads and installs Xcodes
 extension AppState {
@@ -27,8 +28,8 @@ extension AppState {
                     case .version:
                         // If the XIP was just downloaded, remove it and try to recover.
                         do {
-                            Current.logging.log(error.legibleLocalizedDescription)
-                            Current.logging.log("Removing damaged XIP and re-attempting installation.\n")
+                            Logger.appState.error("\(error.legibleLocalizedDescription)")
+                            Logger.appState.info("Removing damaged XIP and re-attempting installation.")
                             try Current.files.removeItem(at: damagedXIPURL)
                             return self.install(installationType, downloader: downloader, attemptNumber: attemptNumber + 1)
                                 .eraseToAnyPublisher()
@@ -82,7 +83,7 @@ extension AppState {
             aria2DownloadIsIncomplete = true
         }
         if Current.files.fileExistsAtPath(expectedArchivePath.string), aria2DownloadIsIncomplete == false {
-            Current.logging.log("(1/6) Found existing archive that will be used for installation at \(expectedArchivePath).")
+            Logger.appState.info("Found existing archive that will be used for installation at \(expectedArchivePath).")
             return Just(expectedArchivePath.url)
                 .setFailureType(to: Error.self)
                 .eraseToAnyPublisher()

--- a/Xcodes/Backend/Environment.swift
+++ b/Xcodes/Backend/Environment.swift
@@ -15,7 +15,6 @@ public struct Environment {
     public var shell = Shell()
     public var files = Files()
     public var network = Network()
-    public var logging = Logging()
     public var keychain = Keychain()
     public var defaults = Defaults()
     public var date: () -> Date = Date.init
@@ -188,10 +187,6 @@ public struct Network {
     public func downloadTask(with url: URL, to saveLocation: URL, resumingWith resumeData: Data?) -> (progress: Progress, publisher: AnyPublisher<(saveLocation: URL, response: URLResponse), Error>) {
         return downloadTask(url, saveLocation, resumeData)
     }
-}
-
-public struct Logging {
-    public var log: (String) -> Void = { print($0) }
 }
 
 public struct Keychain {

--- a/Xcodes/Backend/HelperInstaller.swift
+++ b/Xcodes/Backend/HelperInstaller.swift
@@ -1,6 +1,7 @@
 // From https://github.com/securing/SimpleXPCApp/
 
 import Foundation
+import os.log
 import ServiceManagement
 
 enum HelperAuthorizationError: Error {
@@ -35,8 +36,9 @@ class HelperInstaller {
             let authRef = try authorizationRef(&authRights, nil, [.interactionAllowed, .extendRights, .preAuthorize])
             var cfError: Unmanaged<CFError>?
             SMJobBless(kSMDomainSystemLaunchd, machServiceName as CFString, authRef, &cfError)
-        } catch let err {
-            print("Error in installing the helper -> \(err.localizedDescription)")
+            if let error = cfError?.takeRetainedValue() { throw error }
+        } catch {
+            Logger.helperInstaller.error("\(error.localizedDescription)")
         }
     }
 }

--- a/Xcodes/Backend/Logger.swift
+++ b/Xcodes/Backend/Logger.swift
@@ -1,0 +1,10 @@
+import Foundation
+import os.log
+
+extension Logger {
+    private static var subsystem = Bundle.main.bundleIdentifier!
+
+    static let appState = Logger(subsystem: subsystem, category: "appState")
+    static let helperInstaller = Logger(subsystem: subsystem, category: "helperInstaller")
+    static let subprocess = Logger(subsystem: subsystem, category: "subprocess")
+}

--- a/Xcodes/Backend/Process.swift
+++ b/Xcodes/Backend/Process.swift
@@ -1,5 +1,6 @@
 import Combine
 import Foundation
+import os.log
 import Path
 
 public typealias ProcessOutput = (status: Int32, out: String, err: String)
@@ -32,16 +33,19 @@ extension Process {
                     }
                     
                     do {
-                        print("Process.run \(executable), \(input), \(arguments.joined(separator: " "))")
+                        Logger.subprocess.info("Process.run executable: \(executable), input: \(input ?? ""), arguments: \(arguments.joined(separator: ", "))")
+
                         try process.run()
                         process.waitUntilExit()
                         
                         let output = String(data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
                         let error = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
                         
-                        dump(process)
-                        print(output)
-                        print(error)
+                        Logger.subprocess.info("Process.run output: \(output)")
+                        if !error.isEmpty {
+                            Logger.subprocess.error("Process.run error: \(error)")
+                        }
+
                         guard process.terminationReason == .exit, process.terminationStatus == 0 else {  
                             DispatchQueue.main.async {
                                 promise(.failure(ProcessExecutionError(process: process, standardOutput: output, standardError: error)))

--- a/XcodesTests/Environment+Mock.swift
+++ b/XcodesTests/Environment+Mock.swift
@@ -7,7 +7,6 @@ extension Environment {
         shell: .mock,
         files: .mock,
         network: .mock,
-        logging: .mock,
         keychain: .mock,
         defaults: .mock,
         date: Date.mock,
@@ -70,12 +69,6 @@ extension Network {
                     .eraseToAnyPublisher()
             ) 
         }
-    )
-}
-
-extension Logging {
-    static var mock = Logging(
-        log: { print($0) }
     )
 }
 

--- a/com.robotsandpencils.XcodesApp.Helper/Logger.swift
+++ b/com.robotsandpencils.XcodesApp.Helper/Logger.swift
@@ -1,0 +1,9 @@
+import Foundation
+import os.log
+
+extension Logger {
+    private static var subsystem = Bundle.main.bundleIdentifier!
+
+    static let connectionVerifier = Logger(subsystem: subsystem, category: "connectionVerifier")
+    static let xpcDelegate = Logger(subsystem: subsystem, category: "xpcDelegate")
+}

--- a/com.robotsandpencils.XcodesApp.Helper/XPCDelegate.swift
+++ b/com.robotsandpencils.XcodesApp.Helper/XPCDelegate.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os.log
 
 class XPCDelegate: NSObject, NSXPCListenerDelegate, HelperXPCProtocol {
 
@@ -16,12 +17,12 @@ class XPCDelegate: NSObject, NSXPCListenerDelegate, HelperXPCProtocol {
     // MARK: - HelperXPCProtocol
     
     func getVersion(completion: @escaping (String) -> Void) {
-        NSLog("XPCDelegate: \(#function)")
+        Logger.xpcDelegate.info("\(#function)")
         completion(Bundle.main.infoDictionary!["CFBundleShortVersionString"] as! String)
     }
     
     func xcodeSelect(absolutePath: String, completion: @escaping (Error?) -> Void) {
-        NSLog("XPCDelegate: \(#function)")
+        Logger.xpcDelegate.info("\(#function)")
 
         guard URL(fileURLWithPath: absolutePath).hasDirectoryPath else {
             completion(XPCDelegateError(.invalidXcodePath))
@@ -55,7 +56,7 @@ class XPCDelegate: NSObject, NSXPCListenerDelegate, HelperXPCProtocol {
 // MARK: - Run
 
 private func run(url: URL, arguments: [String], completion: @escaping (Error?) -> Void) {
-    NSLog("XPCDelegate: run \(url) \(arguments)")
+    Logger.xpcDelegate.info("Run executable: \(url), arguments: \(arguments.joined(separator: ", "))")
     
     let process = Process()
     process.executableURL = url


### PR DESCRIPTION
- Removed logging from Environment because it's not as useful as it was in `xcodes`
- Added Logger subsystems and categories for the main app and helper
- Replaced uses of print/dump/NSLog with Logger.error/info as appropriate

I intentionally didn't add more logging than we had, I think we could do that later though. I've wanted a verbose flag for `xcodes` for a while to help debugging, and so more logging might be valuable for the same reasons here.

<img width="1792" alt="Screen Shot 2021-01-12 at 9 55 34 PM" src="https://user-images.githubusercontent.com/594059/104408283-f6a11b80-5520-11eb-9c5e-0dda534c9db2.png">

Testing:

- Open Console.app
- Filter for subsystems containing "xcodes" to pick up both the main app and helper
- Make sure Action > Include Info Messages is enabled
- Do some things in the app
- Make sure that both executables are logging to Console

---

Closes #30 