### PR TITLE
Always show build identifiers in list and info pane

### DIFF
--- a/Xcodes/Backend/AppState+Install.swift
+++ b/Xcodes/Backend/AppState+Install.swift
@@ -411,7 +411,7 @@ public enum InstallationError: LocalizedError, Equatable {
         case .missingSudoerPassword:
             return "Missing password. Please try again."
         case let .unavailableVersion(version):
-            return "Could not find version \(version.xcodeDescription)."
+            return "Could not find version \(version.appleDescription)."
         case .noNonPrereleaseVersionAvailable:
             return "No non-prerelease versions available."
         case .noPrereleaseVersionAvailable:
@@ -419,11 +419,11 @@ public enum InstallationError: LocalizedError, Equatable {
         case .missingUsernameOrPassword:
             return "Missing username or a password. Please try again."
         case let .versionAlreadyInstalled(installedXcode):
-            return "\(installedXcode.version.xcodeDescription) is already installed at \(installedXcode.path)"
+            return "\(installedXcode.version.appleDescription) is already installed at \(installedXcode.path)"
         case let .invalidVersion(version):
             return "\(version) is not a valid version number."
         case let .versionNotInstalled(version):
-            return "\(version.xcodeDescription) is not installed."
+            return "\(version.appleDescription) is not installed."
         }
     }
 }

--- a/Xcodes/Backend/Version+Xcode.swift
+++ b/Xcodes/Backend/Version+Xcode.swift
@@ -38,7 +38,12 @@ public extension Version {
         self = Version(major: major, minor: minor, patch: patch, prereleaseIdentifiers: prereleaseIdentifiers, buildMetadataIdentifiers: [buildMetadataIdentifier].compactMap { $0 })
     }
 
-    var xcodeDescription: String {
+    /// The intent here is to match Apple's marketing version
+    ///
+    /// Only show the patch number if it's not 0
+    /// Format prerelease identifiers
+    /// Don't include build identifiers
+    var appleDescription: String {
         var base = "\(major).\(minor)"
         if patch != 0 {
             base += ".\(patch)"
@@ -47,10 +52,6 @@ public extension Version {
             base += " " + prereleaseIdentifiers
                 .map { $0.replacingOccurrences(of: "-", with: " ").capitalized.replacingOccurrences(of: "Gm", with: "GM") }
                 .joined(separator: " ")
-
-            if !buildMetadataIdentifiers.isEmpty {
-                base += " (\(buildMetadataIdentifiers.joined(separator: " ")))"
-            }
         }
         return base
     }

--- a/Xcodes/Backend/Xcode.swift
+++ b/Xcodes/Backend/Xcode.swift
@@ -37,6 +37,6 @@ struct Xcode: Identifiable, CustomStringConvertible {
     var id: Version { version }
     
     var description: String {
-        version.xcodeDescription
+        version.appleDescription
     }
 }

--- a/Xcodes/Frontend/XcodeList/InfoPane.swift
+++ b/Xcodes/Frontend/XcodeList/InfoPane.swift
@@ -17,7 +17,7 @@ struct InfoPane: View {
                     icon(for: xcode)
                     
                     VStack(alignment: .leading) {
-                        Text("Xcode \(xcode.description)")
+                        Text(verbatim: "Xcode \(xcode.description) (\(xcode.version.buildMetadataIdentifiers.joined(separator: " ")))")
                             .font(.title)
                             .frame(maxWidth: .infinity, alignment: .leading)
                         

--- a/Xcodes/Frontend/XcodeList/XcodeListViewRow.swift
+++ b/Xcodes/Frontend/XcodeList/XcodeListViewRow.swift
@@ -11,8 +11,8 @@ struct XcodeListViewRow: View {
         HStack {
             appIconView(for: xcode)
             
-            VStack(alignment: .leading) {    
-                Text(xcode.description)
+            VStack(alignment: .leading) {
+                Text(verbatim: "\(xcode.description) (\(xcode.version.buildMetadataIdentifiers.joined(separator: " ")))")
                     .font(.body)
                 
                 if case let .installed(path) = xcode.installState {


### PR DESCRIPTION
The previous implementation of Version.xcodeDescription (from `xcodes`) only shows build identifiers for prerelease versions. Instead, we want a "marketing version" with a consistent format that's used in the UI, with the addition of the build identifier in certain places where other metadata is shown, in particular the list and info pane.

I'd wanted to make the build identifiers in the list and info pane Color.secondary, but this negatively impacted scrolling performance (😞) so I left it as Color.primary.

|Before|After|
|-----|-----|
|![Screen Shot 2021-01-16 at 12 35 57 PM](https://user-images.githubusercontent.com/594059/104821316-32293780-57f8-11eb-83b6-7b67a67ad26d.png)|![Screen Shot 2021-01-16 at 12 36 12 PM](https://user-images.githubusercontent.com/594059/104821322-36edeb80-57f8-11eb-8533-0142e1bdd14d.png)|