### PR TITLE
Don't show brackets when buildMetadataIdentifiers is empty

### DIFF
--- a/Xcodes/Backend/Version+XcodeReleases.swift
+++ b/Xcodes/Backend/Version+XcodeReleases.swift
@@ -47,5 +47,9 @@ extension Version {
         
         self.init(versionString)
     }
+    
+    var buildMetadataIdentifiersDisplay: String {
+        return !buildMetadataIdentifiers.isEmpty ? "(\(buildMetadataIdentifiers.joined(separator: " ")))" : ""
+    }
 }
 

--- a/Xcodes/Frontend/XcodeList/InfoPane.swift
+++ b/Xcodes/Frontend/XcodeList/InfoPane.swift
@@ -17,7 +17,7 @@ struct InfoPane: View {
                     icon(for: xcode)
                     
                     VStack(alignment: .leading) {
-                        Text(verbatim: "Xcode \(xcode.description) (\(xcode.version.buildMetadataIdentifiers.joined(separator: " ")))")
+                        Text(verbatim: "Xcode \(xcode.description) \(xcode.version.buildMetadataIdentifiersDisplay)")
                             .font(.title)
                             .frame(maxWidth: .infinity, alignment: .leading)
                         
@@ -254,11 +254,11 @@ struct InfoPane_Previews: PreviewProvider {
                 })
                 .previewDisplayName("Populated, Uninstalled")
             
-            InfoPane(selectedXcodeID: Version(major: 12, minor: 3, patch: 0))
+            InfoPane(selectedXcodeID: Version(major: 12, minor: 3, patch: 1, buildMetadataIdentifiers: ["1234A"]))
                 .environmentObject(configure(AppState()) {
                     $0.allXcodes = [
                         .init(
-                            version: Version(major: 12, minor: 3, patch: 0),
+                            version: Version(major: 12, minor: 3, patch: 1, buildMetadataIdentifiers: ["1234A"]),
                             installState: .installed(Path("/Applications/Xcode-12.3.0.app")!),
                             selected: false,
                             icon: nil,

--- a/Xcodes/Frontend/XcodeList/XcodeListViewRow.swift
+++ b/Xcodes/Frontend/XcodeList/XcodeListViewRow.swift
@@ -12,7 +12,7 @@ struct XcodeListViewRow: View {
             appIconView(for: xcode)
             
             VStack(alignment: .leading) {
-                Text(verbatim: "\(xcode.description) (\(xcode.version.buildMetadataIdentifiers.joined(separator: " ")))")
+                Text(verbatim: "\(xcode.description) \(xcode.version.buildMetadataIdentifiersDisplay)")
                     .font(.body)
                 
                 if case let .installed(path) = xcode.installState {
@@ -120,6 +120,11 @@ struct XcodeListViewRow_Previews: PreviewProvider {
             
             XcodeListViewRow(
                 xcode: Xcode(version: Version("12.0.0")!, installState: .installed(Path("/Applications/Xcode-12.3.0.app")!), selected: false, icon: nil),
+                selected: false
+            )
+            
+            XcodeListViewRow(
+                xcode: Xcode(version: Version("12.0.0+1234A")!, installState: .installed(Path("/Applications/Xcode-12.3.0.app")!), selected: false, icon: nil),
                 selected: false
             )
         }


### PR DESCRIPTION
Fixes #72 

Removes the brackets when the `buildMetadataIdentifiers` property of version is empty.

For simplicity, I added a computed var on our extension for a display property. 

Added a few examples as well for completion. 