### PR TITLE
Updates the App Update copy to be more relevant about app vs xcode

### DIFF
--- a/Xcodes/Frontend/Preferences/UpdatesPreferencePane.swift
+++ b/Xcodes/Frontend/Preferences/UpdatesPreferencePane.swift
@@ -15,12 +15,12 @@ struct UpdatesPreferencePane: View {
             Preferences.Section(title: "Updates") {
                 VStack(alignment: .leading) {
                     Toggle(
-                        "Automatically check for updates", 
+                        "Automatically check for app updates",
                         isOn: $updater.automaticallyChecksForUpdates
                     )
                     
                     Toggle(
-                        "Include prerelease versions", 
+                        "Include prerelease app versions",
                         isOn: $updater.includePrereleaseVersions
                     )
                                         


### PR DESCRIPTION
Fixes #67

Adds the word `app`, to be more clear about App pre releases vs Xcode pre releases. 