### PR TITLE
Catch and reword xip "not enough free space" error

### DIFF
--- a/Xcodes.xcodeproj/project.pbxproj
+++ b/Xcodes.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		CAA858C425A2BE4E00ACF8C0 /* Downloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA858C325A2BE4E00ACF8C0 /* Downloader.swift */; };
 		CAA858CD25A3D8BC00ACF8C0 /* ErrorHandling in Frameworks */ = {isa = PBXBuildFile; productRef = CAA858CC25A3D8BC00ACF8C0 /* ErrorHandling */; };
 		CAA858DB25A3E11F00ACF8C0 /* aria2-release-1.35.0.tar.gz in Resources */ = {isa = PBXBuildFile; fileRef = CAA858DA25A3E11F00ACF8C0 /* aria2-release-1.35.0.tar.gz */; };
+		CAB3AB0E25BCA6C200BF1B04 /* AppStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAD2E7B72449575100113D76 /* AppStateTests.swift */; };
 		CABFA9BB2592EEEA00380FEE /* DateFormatter+.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABFA9BA2592EEEA00380FEE /* DateFormatter+.swift */; };
 		CABFA9BD2592EEEA00380FEE /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABFA9A92592EEE900380FEE /* Environment.swift */; };
 		CABFA9BF2592EEEA00380FEE /* URLSession+DownloadTaskPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABFA9B32592EEEA00380FEE /* URLSession+DownloadTaskPublisher.swift */; };
@@ -808,6 +809,7 @@
 				CAC281E7259FA45A00B8AB0B /* Environment+Mock.swift in Sources */,
 				CAC281E2259FA44600B8AB0B /* Bundle+XcodesTests.swift in Sources */,
 				CA2518EC25A7FF2B00F08414 /* AppStateUpdateTests.swift in Sources */,
+				CAB3AB0E25BCA6C200BF1B04 /* AppStateTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XcodesTests/AppStateTests.swift
+++ b/XcodesTests/AppStateTests.swift
@@ -167,7 +167,7 @@ class AppStateTests: XCTestCase {
                 [.installing(.trashingArchive), .notInstalled, .notInstalled],
                 [.installing(.checkingSecurity), .notInstalled, .notInstalled],
                 [.installing(.finishing), .notInstalled, .notInstalled],
-                [.installed, .notInstalled, .notInstalled]
+                [.installed(Path("/Applications/Xcode-0.0.0.app")!), .notInstalled, .notInstalled]
             ]
         )
     }
@@ -275,7 +275,7 @@ class AppStateTests: XCTestCase {
                 [.installing(.trashingArchive), .notInstalled, .notInstalled],
                 [.installing(.checkingSecurity), .notInstalled, .notInstalled],
                 [.installing(.finishing), .notInstalled, .notInstalled],
-                [.installed, .notInstalled, .notInstalled]
+                [.installed(Path("/Applications/Xcode-0.0.0.app")!), .notInstalled, .notInstalled]
             ]
         )
     }


### PR DESCRIPTION
This change catches the xip error that is output when there's not enough free space to expand a .xip archive and makes sure that it's presented with a better error message.

It also adds AppStateTests to the XcodesTests target, not sure what happened there.

|Before|After|
|-----|-----|
|![Screen Shot 2021-01-23 at 11 17 25 AM](https://user-images.githubusercontent.com/594059/105610884-50021980-5d6f-11eb-9da5-8e43a1de0b74.png)|![Screen Shot 2021-01-23 at 11 32 41 AM](https://user-images.githubusercontent.com/594059/105610888-54c6cd80-5d6f-11eb-9f55-0925a3d837c7.png)|

Closes #77 