### PR TITLE
Handle helper installation errors

### DIFF
--- a/Xcodes/Backend/AppState+Install.swift
+++ b/Xcodes/Backend/AppState+Install.swift
@@ -303,11 +303,10 @@ extension AppState {
     }
 
     func enableDeveloperMode() -> AnyPublisher<Void, Error> {
-        if helperInstallState == .notInstalled {
-            installHelper()
-        }
-
-        return Current.helper.devToolsSecurityEnable()
+        installHelperIfNecessary()
+            .flatMap {
+                Current.helper.devToolsSecurityEnable()
+            }
             .flatMap {
                 Current.helper.addStaffToDevelopersGroup()
             }
@@ -315,20 +314,18 @@ extension AppState {
     }
 
     func approveLicense(for xcode: InstalledXcode) -> AnyPublisher<Void, Error> {
-        if helperInstallState == .notInstalled {
-            installHelper()
-        }
-
-        return Current.helper.acceptXcodeLicense(xcode.path.string)
+        installHelperIfNecessary()
+            .flatMap {
+                Current.helper.acceptXcodeLicense(xcode.path.string)
+            }
             .eraseToAnyPublisher()
     }
 
     func installComponents(for xcode: InstalledXcode) -> AnyPublisher<Void, Swift.Error> {
-        if helperInstallState == .notInstalled {
-            installHelper()
-        }
-
-        return Current.helper.runFirstLaunch(xcode.path.string)
+        installHelperIfNecessary()
+            .flatMap {
+                Current.helper.runFirstLaunch(xcode.path.string)
+            }
             .flatMap {
                 Current.shell.getUserCacheDir().map { $0.out }
                     .combineLatest(

--- a/Xcodes/Backend/Environment.swift
+++ b/Xcodes/Backend/Environment.swift
@@ -237,7 +237,7 @@ public struct Defaults {
 
 private let helperClient = HelperClient()
 public struct Helper {
-    var install: () -> Void = helperClient.install
+    var install: () throws -> Void = helperClient.install
     var checkIfLatestHelperIsInstalled: () -> AnyPublisher<Bool, Never> = helperClient.checkIfLatestHelperIsInstalled
     var getVersion: () -> AnyPublisher<String, Error> = helperClient.getVersion
     var switchXcodePath: (_ absolutePath: String) -> AnyPublisher<Void, Error> = helperClient.switchXcodePath

--- a/Xcodes/Backend/HelperClient.swift
+++ b/Xcodes/Backend/HelperClient.swift
@@ -307,7 +307,7 @@ final class HelperClient {
     // MARK: - Install
     // From https://github.com/securing/SimpleXPCApp/
     
-    func install() {
+    func install() throws {
         Logger.helperClient.info(#function)
 
         var authItem = kSMRightBlessPrivilegedHelper.withCString { name in
@@ -329,6 +329,8 @@ final class HelperClient {
             Logger.helperClient.info("\(#function): Finished installation")
         } catch {
             Logger.helperClient.error("\(#function): \(error.localizedDescription)")
+            
+            throw error
         }
     }
     

--- a/Xcodes/Backend/HelperClient.swift
+++ b/Xcodes/Backend/HelperClient.swift
@@ -337,7 +337,11 @@ final class HelperClient {
     private func executeAuthorizationFunction(_ authorizationFunction: () -> (OSStatus) ) throws {
         let osStatus = authorizationFunction()
         guard osStatus == errAuthorizationSuccess else {
-            throw HelperClientError.message(String(describing: SecCopyErrorMessageString(osStatus, nil)))
+            if let message = SecCopyErrorMessageString(osStatus, nil) {
+                throw HelperClientError.message(String(message as NSString))
+            } else {
+                throw HelperClientError.message("Unknown error")
+            }
         }
     }
     

--- a/Xcodes/Frontend/Preferences/AdvancedPreferencePane.swift
+++ b/Xcodes/Frontend/Preferences/AdvancedPreferencePane.swift
@@ -55,7 +55,7 @@ struct AdvancedPreferencePane: View {
                         HStack {
                             Text("Helper is not installed")
                             Button("Install helper") {
-                                appState.installHelper()
+                                appState.installHelperIfNecessary()
                             }
                         }
                     }


### PR DESCRIPTION
Instead of ignoring errors (either cancellation or failure) from helper installation, this change throws them so callers can react appropriately. Previously, whatever was being done that required the helper would proceed as if installation succeeded, which would always fail. Now, cancellation or failures will complete the subscriptions without attempting the next steps, and without showing more errors to the user. The initial error, for example cancellation in the below screenshot, will still be shown.

The second commit makes a small change to how auth error messages are created to avoid describing the optional wrapper type with `Optional(...)`.

|after cancelling helper installation|
|-----|
|![Screen Shot 2021-01-23 at 1 51 35 PM](https://user-images.githubusercontent.com/594059/105613792-1edf1480-5d82-11eb-881c-bc6c1bfbf70c.png)|


Closes #69 