### PR TITLE
Show ToolTip on progress indicator

### DIFF
--- a/Xcodes/Frontend/Common/ProgressIndicator.swift
+++ b/Xcodes/Frontend/Common/ProgressIndicator.swift
@@ -23,7 +23,6 @@ struct ProgressIndicator: NSViewRepresentable {
         nsView.controlSize = controlSize
         nsView.isIndeterminate = isIndeterminate
         nsView.style = style
-        nsView.toolTip = "Dowloading: \(Int(doubleValue * 100.0))% complete"
     }
 }
 

--- a/Xcodes/Frontend/Common/ProgressIndicator.swift
+++ b/Xcodes/Frontend/Common/ProgressIndicator.swift
@@ -23,6 +23,7 @@ struct ProgressIndicator: NSViewRepresentable {
         nsView.controlSize = controlSize
         nsView.isIndeterminate = isIndeterminate
         nsView.style = style
+        nsView.toolTip = "Dowloading: \(Int(doubleValue * 100.0))% complete"
     }
 }
 

--- a/Xcodes/Frontend/XcodeList/InstallationStepView.swift
+++ b/Xcodes/Frontend/XcodeList/InstallationStepView.swift
@@ -17,6 +17,7 @@ struct InstallationStepView: View {
                     controlSize: .small,
                     style: .spinning
                 )
+                .help("Dowloading: \(Int((progress.fractionCompleted * 100)))% complete")
             case .unarchiving, .moving, .trashingArchive, .checkingSecurity, .finishing:
                 ProgressView()
                     .scaleEffect(0.5)


### PR DESCRIPTION
I didn't like not knowing what percent my download was at, so a quick win is to show it on the tooltip

![image](https://user-images.githubusercontent.com/1119565/105614823-8e103500-5d91-11eb-8f44-7edaf25ba3fe.png)

