### PR TITLE
Prepare user for helper installation before attempting to install

### DIFF
--- a/Xcodes.xcodeproj/project.pbxproj
+++ b/Xcodes.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		CAC281DA259F985100B8AB0B /* InstallationStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC281D9259F985100B8AB0B /* InstallationStep.swift */; };
 		CAC281E2259FA44600B8AB0B /* Bundle+XcodesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC281E1259FA44600B8AB0B /* Bundle+XcodesTests.swift */; };
 		CAC281E7259FA45A00B8AB0B /* Environment+Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC281E6259FA45A00B8AB0B /* Environment+Mock.swift */; };
+		CAC9F92D25BCDA4400B4965F /* HelperInstallState.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC9F92C25BCDA4400B4965F /* HelperInstallState.swift */; };
 		CAD2E7A22449574E00113D76 /* XcodesApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAD2E7A12449574E00113D76 /* XcodesApp.swift */; };
 		CAD2E7A42449574E00113D76 /* XcodeListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAD2E7A32449574E00113D76 /* XcodeListView.swift */; };
 		CAD2E7A62449575000113D76 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CAD2E7A52449575000113D76 /* Assets.xcassets */; };
@@ -231,6 +232,7 @@
 		CAC281D9259F985100B8AB0B /* InstallationStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallationStep.swift; sourceTree = "<group>"; };
 		CAC281E1259FA44600B8AB0B /* Bundle+XcodesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+XcodesTests.swift"; sourceTree = "<group>"; };
 		CAC281E6259FA45A00B8AB0B /* Environment+Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Environment+Mock.swift"; sourceTree = "<group>"; };
+		CAC9F92C25BCDA4400B4965F /* HelperInstallState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelperInstallState.swift; sourceTree = "<group>"; };
 		CAD2E79E2449574E00113D76 /* Xcodes.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Xcodes.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CAD2E7A12449574E00113D76 /* XcodesApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcodesApp.swift; sourceTree = "<group>"; };
 		CAD2E7A32449574E00113D76 /* XcodeListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcodeListView.swift; sourceTree = "<group>"; };
@@ -417,6 +419,7 @@
 				CAFBDB942598FE96003DCC5A /* FocusedValues.swift */,
 				CABFA9AC2592EEE900380FEE /* Foundation.swift */,
 				CA9FF9352595B44700E47BAF /* HelperClient.swift */,
+				CAC9F92C25BCDA4400B4965F /* HelperInstallState.swift */,
 				CAC281D9259F985100B8AB0B /* InstallationStep.swift */,
 				CA9FF8862595607900E47BAF /* InstalledXcode.swift */,
 				CAA8587B25A2B37900ACF8C0 /* IsTesting.swift */,
@@ -779,6 +782,7 @@
 				CABFAA2D2592FBFC00380FEE /* Configure.swift in Sources */,
 				CA73510D257BFCEF00EA9CF8 /* NSAttributedString+.swift in Sources */,
 				CAFBDB952598FE96003DCC5A /* FocusedValues.swift in Sources */,
+				CAC9F92D25BCDA4400B4965F /* HelperInstallState.swift in Sources */,
 				CAC281CD259F97FA00B8AB0B /* ObservingProgressIndicator.swift in Sources */,
 				CABFA9C22592EEEA00380FEE /* Publisher+Resumable.swift in Sources */,
 				CAFBDC68259A308B003DCC5A /* InfoPane.swift in Sources */,

--- a/Xcodes/Backend/AppState.swift
+++ b/Xcodes/Backend/AppState.swift
@@ -496,12 +496,6 @@ class AppState: ObservableObject {
 
     // MARK: - Nested Types
 
-    enum HelperInstallState: Equatable {
-        case unknown
-        case notInstalled
-        case installed
-    }
-
     struct AlertContent: Identifiable {
         var title: String
         var message: String

--- a/Xcodes/Backend/HelperInstallState.swift
+++ b/Xcodes/Backend/HelperInstallState.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public enum HelperInstallState: Equatable {
+    case unknown
+    case notInstalled
+    case installed
+}

--- a/Xcodes/Frontend/MainWindow.swift
+++ b/Xcodes/Frontend/MainWindow.swift
@@ -58,9 +58,29 @@ struct MainWindow: View {
                         title: Text("Privileged Helper"), 
                         message: Text("Xcodes uses a separate privileged helper to perform tasks as root. These are things that would require sudo on the command line, including post-install steps and switching Xcode versions with xcode-select.\n\nYou'll be prompted for your macOS account password to install it."), 
                         primaryButton: .default(Text("Install"), action: {
-                            DispatchQueue.main.async(execute: appState.isPreparingUserForActionRequiringHelper!)
+                            // The isPreparingUserForActionRequiringHelper closure is set to nil by the alert's binding when its dismissed.
+                            // We need to capture it to be invoked after that happens.
+                            let helperAction = appState.isPreparingUserForActionRequiringHelper
+                            DispatchQueue.main.async { 
+                                // This really shouldn't be nil, but sometimes this alert is being shown twice and I don't know why.
+                                // There are some DispatchQueue.main.async's scattered around which make this better but in some situations it's still happening.
+                                // When that happens, the second time the user clicks an alert button isPreparingUserForActionRequiringHelper will be nil.
+                                // To at least not crash, we're using ?
+                                helperAction?(true) 
+                            }
                         }), 
-                        secondaryButton: .cancel()
+                        secondaryButton: .cancel {
+                            // The isPreparingUserForActionRequiringHelper closure is set to nil by the alert's binding when its dismissed.
+                            // We need to capture it to be invoked after that happens.
+                            let helperAction = appState.isPreparingUserForActionRequiringHelper
+                            DispatchQueue.main.async {
+                                // This really shouldn't be nil, but sometimes this alert is being shown twice and I don't know why.
+                                // There are some DispatchQueue.main.async's scattered around which make this better but in some situations it's still happening.
+                                // When that happens, the second time the user clicks an alert button isPreparingUserForActionRequiringHelper will be nil.
+                                // To at least not crash, we're using ?
+                                helperAction?(false) 
+                            }
+                        }
                     )
                 }
         )

--- a/Xcodes/Frontend/MainWindow.swift
+++ b/Xcodes/Frontend/MainWindow.swift
@@ -50,6 +50,20 @@ struct MainWindow: View {
             secondFactorView(appState.secondFactorData!)
                 .environmentObject(appState)
         }
+        // This overlay is only here to work around the one-alert-per-view limitation
+        .overlay(
+            Color.clear
+                .alert(isPresented: $appState.isPreparingUserForActionRequiringHelper.isNotNil) {
+                    Alert(
+                        title: Text("Privileged Helper"), 
+                        message: Text("Xcodes uses a separate privileged helper to perform tasks as root. These are things that would require sudo on the command line, including post-install steps and switching Xcode versions with xcode-select.\n\nYou'll be prompted for your macOS account password to install it."), 
+                        primaryButton: .default(Text("Install"), action: {
+                            DispatchQueue.main.async(execute: appState.isPreparingUserForActionRequiringHelper!)
+                        }), 
+                        secondaryButton: .cancel()
+                    )
+                }
+        )
         // I'm expecting to be able to use this modifier on a List row, but using it at the top level here is the only way that has made XcodeCommands work so far.
         // FB8954571 focusedValue(_:_:) on List row doesn't propagate value to @FocusedValue
         .focusedValue(\.selectedXcode, SelectedXcode(appState.allXcodes.first { $0.id == selectedXcodeID }))

--- a/Xcodes/Frontend/Preferences/AdvancedPreferencePane.swift
+++ b/Xcodes/Frontend/Preferences/AdvancedPreferencePane.swift
@@ -60,7 +60,7 @@ struct AdvancedPreferencePane: View {
                         }
                     }
                     
-                    Text("Xcodes uses a separate privileged helper to perform tasks as root. These are things that would require sudo on the command line, including post-install steps and switching Xcode versions with xcode-select.")
+                    Text("Xcodes uses a separate privileged helper to perform tasks as root. These are things that would require sudo on the command line, including post-install steps and switching Xcode versions with xcode-select.\n\nYou'll be prompted for your macOS account password to install it.")
                         .font(.footnote)
                         .fixedSize(horizontal: false, vertical: true)
                     

--- a/Xcodes/Frontend/XcodeList/XcodeListViewRow.swift
+++ b/Xcodes/Frontend/XcodeList/XcodeListViewRow.swift
@@ -37,13 +37,20 @@ struct XcodeListViewRow: View {
                 InstallButton(xcode: xcode)
             case .installing:
                 CancelInstallButton(xcode: xcode)
-            case .installed:
+            case let .installed(path):
                 SelectButton(xcode: xcode)
                 OpenButton(xcode: xcode)
                 RevealButton(xcode: xcode)
                 CopyPathButton(xcode: xcode)
                 Divider()
                 UninstallButton(xcode: xcode)
+                
+                #if DEBUG
+                Divider()
+                Button("Perform post-install steps") {
+                    appState.performPostInstallSteps(for: InstalledXcode(path: path)!) as Void
+                }
+                #endif
             }
         }
     }

--- a/XcodesTests/AppStateTests.swift
+++ b/XcodesTests/AppStateTests.swift
@@ -148,6 +148,8 @@ class AppStateTests: XCTestCase {
             .setFailureType(to: Error.self)
             .eraseToAnyPublisher()
         }
+        // Helper is already installed
+        subject.helperInstallState = .installed
 
         let allXcodesRecorder = subject.$allXcodes.record()
         let installRecorder = subject.install(
@@ -256,6 +258,8 @@ class AppStateTests: XCTestCase {
             .setFailureType(to: Error.self)
             .eraseToAnyPublisher()
         }
+        // Helper is already installed
+        subject.helperInstallState = .installed
 
         let allXcodesRecorder = subject.$allXcodes.record()
         let installRecorder = subject.install(


### PR DESCRIPTION
The intent of this change is to make sure users are prepared to enter their macOS account password in the helper installation alert so that they aren't surprised and cancel installation, which leads to further failures.

This affects making Xcode versions active and the "step 6: finishing" post-install steps of installation.

The implementation of these changes aren't straightforward (I think), as most of the logic is implemented in publishers that now have to wait on user interaction in the preparation alert. This is done in two different ways because the way these methods are invoked is a little different:

- `select(id:shouldPrepareUserForHelperInstallation:)` is invoked once and returns early to prepare the user. Once the user makes a decision in the preparation alert the method is automatically invoked a second time to perform the action if they consented to installation. If they didn't consent then nothing happens. They can just try to make the version active again.
- `performPostInstallSteps(for:)` is invoked only once as part of a larger installation publisher. It returns one of two publishers. If the helper is not already installed, it'll return a publisher that waits for the user to make a decision in the preparation alert before continuing with the post-install steps. If the helper is already installed, the method will return a publisher that only performs the post-install steps. If the user doesn't consent to installation, the publisher fails so that they can be informed what the result of installation with the post-install steps being performed is. This is different from `select` because there is no "just try clicking it again" option in this case.

The user is be prepared and prompted for installation only once for all three post-install steps.

Because the post-install steps are optional as far as Xcodes.app is concerned (the user will just have to perform them manually when they launch the new Xcode), an alert is shown with an error message explaining what happened, but this doesn't cause installation to fail.

---

## Testing

- Install an Xcode and when the preparation alert is shown, cancel. You should see an error about the post-install steps not being performed, but the new Xcode should appear installed. (The button on the right should read "Open" instead of "Install")
- Install an Xcode and when the preparation alert is shown, click Install, but then cancel the helper installation alert. You should see an error about the post-install steps not being performed, but the new Xcode should appear installed.
- Install an Xcode and when the preparation alert is shown, click Install, and then enter your macOS account password to install the helper. You should see no errors and the new Xcode should appear installed.
- Clicking the alert buttons in different situations, particularly when the window is inactive, should always perform the button's action, and may present an alert twice, but should never crash. I don't know why the double alert thing is happening but I think this is the best combination of those three things for now.

I also added a "Perform post-install steps" context menu item to the list row context menu which is only shown in debug builds.

|Preparation alert|Post-install failed with helper|Post-install failed without helper|
|-----|-----|-----|
|![Screen Shot 2021-01-23 at 7 56 37 PM](https://user-images.githubusercontent.com/594059/105619987-21a72d00-5db5-11eb-85a1-18d9b5227833.png)|![Screen Shot 2021-01-23 at 3 24 54 PM](https://user-images.githubusercontent.com/594059/105619923-93cb4200-5db4-11eb-976e-b5857f35bed5.png)|![Screen Shot 2021-01-23 at 3 31 24 PM](https://user-images.githubusercontent.com/594059/105619924-97f75f80-5db4-11eb-83f1-973196b38cf2.png)|

---

Closes #66