### PR TITLE
Show stored username in General preference pane even when we don't have a valid session

### DIFF
--- a/Xcodes/Backend/AppState.swift
+++ b/Xcodes/Backend/AppState.swift
@@ -179,6 +179,7 @@ class AppState: ObservableObject {
                let username = Current.defaults.string(forKey: "username") {
                 // remove any keychain password if we fail to log with an invalid username or password so it doesn't try again.
                 try? Current.keychain.remove(username)
+                Current.defaults.removeObject(forKey: "username")
             }
 
             // This error message is not user friendly... need to extract some meaningful data in the different cases

--- a/Xcodes/Frontend/Preferences/GeneralPreferencePane.swift
+++ b/Xcodes/Frontend/Preferences/GeneralPreferencePane.swift
@@ -13,8 +13,13 @@ struct GeneralPreferencePane: View {
         Preferences.Container(contentWidth: 400.0) {
             Preferences.Section(title: "Apple ID") {
                 VStack(alignment: .leading) {
-                    if appState.authenticationState == .authenticated {
-                        Text(Current.defaults.string(forKey: "username") ?? "-")
+                    // If we have saved a username then we will show it here,
+                    // even if we don't have a valid session right now,
+                    // because we should be able to get a valid session if needed with the password in the keychain 
+                    // and a 2FA code from the user.
+                    // Note that AppState.authenticationState is not necessarily .authenticated in this case, though.
+                    if let username = Current.defaults.string(forKey: "username") {
+                        Text(username)
                         Button("Sign Out", action: appState.signOut)
                     } else {
                         Button("Sign In", action: { self.appState.presentingSignInAlert = true })


### PR DESCRIPTION
This reverts the change from 90c067997bdd3e1e3a18c7896baa6d119fcc61ba (in #45) so that the username is shown in situations where we don't have a valid session but could almost certainly get one. Instead, to achieve what that commit was trying to do (not appear signed in when auth failed), we'll instead remove the username from UserDefaults if auth fails with an invalid username or password error. I think this will more closely match what users expect in this UI.

I've added a comment in the UI explaining why it is the way it is. It might also be worth considering renaming AuthenticationState or its cases to better reflect that it's probably more about the (short-lived) session state than whether the user has signed in before and has stored their credentials.

## Testing

- Run the app on `main`
- Sign in in Preferences > General
- Re-run the app
- Open Preferences > General and see that it appears as if you're not signed in

- Run the app on this branch
- Sign in in Preferences > General
- Re-run the app
- Open Preferences > General and see that it appears as if you are signed in

- Verify that auth still works by installing an Xcode or refreshing data while using the Apple data source. In either case you should at most be prompted to enter a 2FA code, and it shouldn't fail with an auth error.