### PR TITLE
Updates PreferencesView To use built in Settings Scene

### DIFF
--- a/Xcodes.xcodeproj/project.pbxproj
+++ b/Xcodes.xcodeproj/project.pbxproj
@@ -100,6 +100,7 @@
 		CAFE4AB425B7D3AF0064FE51 /* AdvancedPreferencePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFE4AB325B7D3AF0064FE51 /* AdvancedPreferencePane.swift */; };
 		CAFE4ABC25B7D54B0064FE51 /* UpdatesPreferencePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFE4ABB25B7D54B0064FE51 /* UpdatesPreferencePane.swift */; };
 		CAFFFED8259CDA5000903F81 /* XcodeListViewRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFFFED7259CDA5000903F81 /* XcodeListViewRow.swift */; };
+		E8977EA325C11E1500835F80 /* PreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8977EA225C11E1500835F80 /* PreferencesView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -260,6 +261,7 @@
 		CAFE4ABB25B7D54B0064FE51 /* UpdatesPreferencePane.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UpdatesPreferencePane.swift; sourceTree = "<group>"; };
 		CAFFFED7259CDA5000903F81 /* XcodeListViewRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcodeListViewRow.swift; sourceTree = "<group>"; };
 		CAFFFEEE259CEAC400903F81 /* RingProgressViewStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RingProgressViewStyle.swift; sourceTree = "<group>"; };
+		E8977EA225C11E1500835F80 /* PreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -542,6 +544,7 @@
 				CAFE4AB325B7D3AF0064FE51 /* AdvancedPreferencePane.swift */,
 				CAFE4AAB25B7D2C70064FE51 /* GeneralPreferencePane.swift */,
 				CAFE4ABB25B7D54B0064FE51 /* UpdatesPreferencePane.swift */,
+				E8977EA225C11E1500835F80 /* PreferencesView.swift */,
 			);
 			path = Preferences;
 			sourceTree = "<group>";
@@ -794,6 +797,7 @@
 				CAE424B4259A764700B8B246 /* AppState+Install.swift in Sources */,
 				CAE42487259A68A300B8B246 /* XcodeListCategory.swift in Sources */,
 				CAA858C425A2BE4E00ACF8C0 /* Downloader.swift in Sources */,
+				E8977EA325C11E1500835F80 /* PreferencesView.swift in Sources */,
 				CA9FF87B2595293E00E47BAF /* DataSource.swift in Sources */,
 				CABFA9C92592EEEA00380FEE /* URLRequest+Apple.swift in Sources */,
 				CABFAA432593104F00380FEE /* AboutView.swift in Sources */,

--- a/Xcodes.xcodeproj/project.pbxproj
+++ b/Xcodes.xcodeproj/project.pbxproj
@@ -95,7 +95,6 @@
 		CAFBDC68259A308B003DCC5A /* InfoPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFBDC67259A308B003DCC5A /* InfoPane.swift */; };
 		CAFBDC6C259A3098003DCC5A /* View+Conditional.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFBDC6B259A3098003DCC5A /* View+Conditional.swift */; };
 		CAFE4A9A25B7C7A30064FE51 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = CAFE4A9925B7C7A30064FE51 /* Sparkle */; };
-		CAFE4AA325B7CF960064FE51 /* Preferences in Frameworks */ = {isa = PBXBuildFile; productRef = CAFE4AA225B7CF960064FE51 /* Preferences */; };
 		CAFE4AAC25B7D2C70064FE51 /* GeneralPreferencePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFE4AAB25B7D2C70064FE51 /* GeneralPreferencePane.swift */; };
 		CAFE4AB425B7D3AF0064FE51 /* AdvancedPreferencePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFE4AB325B7D3AF0064FE51 /* AdvancedPreferencePane.swift */; };
 		CAFE4ABC25B7D54B0064FE51 /* UpdatesPreferencePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFE4ABB25B7D54B0064FE51 /* UpdatesPreferencePane.swift */; };
@@ -277,7 +276,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				CAFE4A9A25B7C7A30064FE51 /* Sparkle in Frameworks */,
-				CAFE4AA325B7CF960064FE51 /* Preferences in Frameworks */,
 				CABFA9E42592F08E00380FEE /* Version in Frameworks */,
 				CABFA9FD2592F13300380FEE /* LegibleError in Frameworks */,
 				CA9FF86D25951C6E00E47BAF /* XCModel in Frameworks */,
@@ -596,7 +594,6 @@
 				CA9FF86C25951C6E00E47BAF /* XCModel */,
 				CAA858CC25A3D8BC00ACF8C0 /* ErrorHandling */,
 				CAFE4A9925B7C7A30064FE51 /* Sparkle */,
-				CAFE4AA225B7CF960064FE51 /* Preferences */,
 			);
 			productName = XcodesMac;
 			productReference = CAD2E79E2449574E00113D76 /* Xcodes.app */;
@@ -664,7 +661,6 @@
 				CAA858CB25A3D8BC00ACF8C0 /* XCRemoteSwiftPackageReference "ErrorHandling" */,
 				CAC28186259EE27200B8AB0B /* XCRemoteSwiftPackageReference "CombineExpectations" */,
 				CAFE4A9825B7C7A30064FE51 /* XCRemoteSwiftPackageReference "Sparkle" */,
-				CAFE4AA125B7CF960064FE51 /* XCRemoteSwiftPackageReference "Preferences" */,
 			);
 			productRefGroup = CAD2E79F2449574E00113D76 /* Products */;
 			projectDirPath = "";
@@ -1341,14 +1337,6 @@
 				version = "1.24.0-spm";
 			};
 		};
-		CAFE4AA125B7CF960064FE51 /* XCRemoteSwiftPackageReference "Preferences" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/sindresorhus/Preferences";
-			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 2.2.0;
-			};
-		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1400,11 +1388,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = CAFE4A9825B7C7A30064FE51 /* XCRemoteSwiftPackageReference "Sparkle" */;
 			productName = Sparkle;
-		};
-		CAFE4AA225B7CF960064FE51 /* Preferences */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = CAFE4AA125B7CF960064FE51 /* XCRemoteSwiftPackageReference "Preferences" */;
-			productName = Preferences;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Xcodes.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Xcodes.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -56,15 +56,6 @@
         }
       },
       {
-        "package": "Preferences",
-        "repositoryURL": "https://github.com/sindresorhus/Preferences",
-        "state": {
-          "branch": null,
-          "revision": "4802a493acef50c814e4eb63e9a44e0941ec8883",
-          "version": "2.2.0"
-        }
-      },
-      {
         "package": "Sparkle",
         "repositoryURL": "https://github.com/sparkle-project/Sparkle/",
         "state": {

--- a/Xcodes/Frontend/Preferences/AdvancedPreferencePane.swift
+++ b/Xcodes/Frontend/Preferences/AdvancedPreferencePane.swift
@@ -8,7 +8,7 @@ struct AdvancedPreferencePane: View {
     
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
-            GroupBox(label: Text("DataSource")) {
+            GroupBox(label: Text("Data Source")) {
                 VStack(alignment: .leading) {
                     Picker("Data Source", selection: $dataSource) {
                         ForEach(DataSource.allCases) { dataSource in
@@ -66,8 +66,7 @@ struct AdvancedPreferencePane: View {
             }
             .groupBoxStyle(PreferencesGroupBoxStyle())
         }
-        .padding()
-        .frame(width: 500)
+        .frame(width: 400)
     }
     
     private var dataSourceFootnote: NSAttributedString {

--- a/Xcodes/Frontend/Preferences/AdvancedPreferencePane.swift
+++ b/Xcodes/Frontend/Preferences/AdvancedPreferencePane.swift
@@ -2,10 +2,6 @@ import AppleAPI
 import Preferences
 import SwiftUI
 
-extension Preferences.PaneIdentifier {
-    static let advanced = Self("advanced")
-}
-
 struct AdvancedPreferencePane: View {
     @EnvironmentObject var appState: AppState
     @AppStorage("dataSource") var dataSource: DataSource = .xcodeReleases

--- a/Xcodes/Frontend/Preferences/AdvancedPreferencePane.swift
+++ b/Xcodes/Frontend/Preferences/AdvancedPreferencePane.swift
@@ -1,5 +1,4 @@
 import AppleAPI
-import Preferences
 import SwiftUI
 
 struct AdvancedPreferencePane: View {
@@ -8,8 +7,8 @@ struct AdvancedPreferencePane: View {
     @AppStorage("downloader") var downloader: Downloader = .aria2
     
     var body: some View {
-        Preferences.Container(contentWidth: 400.0) {
-            Preferences.Section(title: "Data Source") {
+        VStack(alignment: .leading, spacing: 20) {
+            GroupBox(label: Text("DataSource")) {
                 VStack(alignment: .leading) {
                     Picker("Data Source", selection: $dataSource) {
                         ForEach(DataSource.allCases) { dataSource in
@@ -21,10 +20,11 @@ struct AdvancedPreferencePane: View {
                     
                     AttributedText(dataSourceFootnote)
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
+              
             }
+            .groupBoxStyle(PreferencesGroupBoxStyle())
             
-            Preferences.Section(title: "Downloader") {
+            GroupBox(label: Text("Downloader")) {
                 VStack(alignment: .leading) {
                     Picker("Downloader", selection: $downloader) {
                         ForEach(Downloader.allCases) { downloader in
@@ -36,10 +36,11 @@ struct AdvancedPreferencePane: View {
                     
                     AttributedText(downloaderFootnote)
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
+                
             }
+            .groupBoxStyle(PreferencesGroupBoxStyle())
             
-            Preferences.Section(title: "Privileged Helper") {
+            GroupBox(label: Text("Privileged Helper")) {
                 VStack(alignment: .leading, spacing: 8) {
                     switch appState.helperInstallState {
                     case .unknown:
@@ -63,8 +64,10 @@ struct AdvancedPreferencePane: View {
                     Spacer()
                 }
             }
+            .groupBoxStyle(PreferencesGroupBoxStyle())
         }
-        .padding(.trailing)
+        .padding()
+        .frame(width: 500)
     }
     
     private var dataSourceFootnote: NSAttributedString {
@@ -107,6 +110,23 @@ struct AdvancedPreferencePane_Previews: PreviewProvider {
         Group {
             AdvancedPreferencePane()
                 .environmentObject(AppState())
+        }
+    }
+}
+
+// A group style for the preferences
+struct PreferencesGroupBoxStyle: GroupBoxStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        HStack(alignment: .top, spacing: 20) {
+            HStack {
+                Spacer()
+                configuration.label
+            }
+            .frame(width: 120)
+            
+            VStack(alignment: .leading) {
+                configuration.content
+            }
         }
     }
 }

--- a/Xcodes/Frontend/Preferences/GeneralPreferencePane.swift
+++ b/Xcodes/Frontend/Preferences/GeneralPreferencePane.swift
@@ -29,8 +29,7 @@ struct GeneralPreferencePane: View {
                     .environmentObject(appState)
             }
         }
-        .padding()
-        .frame(width: 500)
+        .frame(width: 400)
     }
 }
 

--- a/Xcodes/Frontend/Preferences/GeneralPreferencePane.swift
+++ b/Xcodes/Frontend/Preferences/GeneralPreferencePane.swift
@@ -1,36 +1,36 @@
 import AppleAPI
-import Preferences
 import SwiftUI
 
 struct GeneralPreferencePane: View {
     @EnvironmentObject var appState: AppState
    
     var body: some View {
-        Preferences.Container(contentWidth: 400.0) {
-            Preferences.Section(title: "Apple ID") {
-                VStack(alignment: .leading) {
+        VStack(alignment: .leading) {
+            GroupBox(label: Text("Apple ID")) {
                     // If we have saved a username then we will show it here,
                     // even if we don't have a valid session right now,
                     // because we should be able to get a valid session if needed with the password in the keychain 
                     // and a 2FA code from the user.
                     // Note that AppState.authenticationState is not necessarily .authenticated in this case, though.
                     if let username = Current.defaults.string(forKey: "username") {
-                        Text(username)
-                        Button("Sign Out", action: appState.signOut)
+                        HStack(alignment:.top, spacing: 10) {
+                            Text(username)
+                            Button("Sign Out", action: appState.signOut)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
                     } else {
                         Button("Sign In", action: { self.appState.presentingSignInAlert = true })
+                            .frame(maxWidth: .infinity, alignment: .leading)
                     }
-                    
-                    Spacer()
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .sheet(isPresented: $appState.presentingSignInAlert) {
-                    SignInCredentialsView(isPresented: $appState.presentingSignInAlert)
-                        .environmentObject(appState)
-                }
+            }
+            .groupBoxStyle(PreferencesGroupBoxStyle())
+            .sheet(isPresented: $appState.presentingSignInAlert) {
+                SignInCredentialsView(isPresented: $appState.presentingSignInAlert)
+                    .environmentObject(appState)
             }
         }
-        .padding(.trailing)
+        .padding()
+        .frame(width: 500)
     }
 }
 

--- a/Xcodes/Frontend/Preferences/GeneralPreferencePane.swift
+++ b/Xcodes/Frontend/Preferences/GeneralPreferencePane.swift
@@ -2,13 +2,9 @@ import AppleAPI
 import Preferences
 import SwiftUI
 
-extension Preferences.PaneIdentifier {
-    static let general = Self("general")
-}
-
 struct GeneralPreferencePane: View {
     @EnvironmentObject var appState: AppState
-    
+   
     var body: some View {
         Preferences.Container(contentWidth: 400.0) {
             Preferences.Section(title: "Apple ID") {

--- a/Xcodes/Frontend/Preferences/PreferencesView.swift
+++ b/Xcodes/Frontend/Preferences/PreferencesView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct PreferencesView: View {
+    private enum Tabs: Hashable {
+        case general, updates, advanced
+    }
+    @EnvironmentObject var appState: AppState
+    
+    var body: some View {
+        TabView {
+            GeneralPreferencePane()
+                .environmentObject(appState)
+                .tabItem {
+                    Label("General", systemImage: "gearshape")
+                }
+                .tag(Tabs.general)
+            UpdatesPreferencePane()
+                .tabItem {
+                    Label("Updates", systemImage: "arrow.triangle.2.circlepath.circle")
+                }
+                .tag(Tabs.updates)
+            AdvancedPreferencePane()
+                .environmentObject(appState)
+                .tabItem {
+                    Label("Advanced", systemImage: "gearshape.2")
+                }
+                .tag(Tabs.advanced)
+        }
+        .padding(20)
+    }
+}

--- a/Xcodes/Frontend/Preferences/UpdatesPreferencePane.swift
+++ b/Xcodes/Frontend/Preferences/UpdatesPreferencePane.swift
@@ -28,8 +28,7 @@ struct UpdatesPreferencePane: View {
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .groupBoxStyle(PreferencesGroupBoxStyle())
-        .padding()
-        .frame(width: 500)
+        .frame(width: 400)
     }
     
     private var lastUpdatedString: String {

--- a/Xcodes/Frontend/Preferences/UpdatesPreferencePane.swift
+++ b/Xcodes/Frontend/Preferences/UpdatesPreferencePane.swift
@@ -3,10 +3,6 @@ import Preferences
 import Sparkle
 import SwiftUI
 
-extension Preferences.PaneIdentifier {
-    static let updates = Self("updates")
-}
-
 struct UpdatesPreferencePane: View {
     @StateObject var updater = ObservableUpdater()
     

--- a/Xcodes/Frontend/Preferences/UpdatesPreferencePane.swift
+++ b/Xcodes/Frontend/Preferences/UpdatesPreferencePane.swift
@@ -1,5 +1,4 @@
 import AppleAPI
-import Preferences
 import Sparkle
 import SwiftUI
 
@@ -7,30 +6,30 @@ struct UpdatesPreferencePane: View {
     @StateObject var updater = ObservableUpdater()
     
     var body: some View {
-        Preferences.Container(contentWidth: 400.0) {
-            Preferences.Section(title: "Updates") {
-                VStack(alignment: .leading) {
-                    Toggle(
-                        "Automatically check for app updates",
-                        isOn: $updater.automaticallyChecksForUpdates
-                    )
-                    
-                    Toggle(
-                        "Include prerelease app versions",
-                        isOn: $updater.includePrereleaseVersions
-                    )
-                                        
-                    Button("Check Now") {
-                        SUUpdater.shared()?.checkForUpdates(nil)
-                    }
-
-                    Text("Last checked: \(lastUpdatedString)")
-                        .font(.footnote)
+        GroupBox(label: Text("Updates")) {
+            VStack(alignment: .leading) {
+                Toggle(
+                    "Automatically check for app updates",
+                    isOn: $updater.automaticallyChecksForUpdates
+                )
+                
+                Toggle(
+                    "Include prerelease app versions",
+                    isOn: $updater.includePrereleaseVersions
+                )
+                                    
+                Button("Check Now") {
+                    SUUpdater.shared()?.checkForUpdates(nil)
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
+
+                Text("Last checked: \(lastUpdatedString)")
+                    .font(.footnote)
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .padding(.trailing)
+        .groupBoxStyle(PreferencesGroupBoxStyle())
+        .padding()
+        .frame(width: 500)
     }
     
     private var lastUpdatedString: String {

--- a/Xcodes/Resources/Licenses.rtf
+++ b/Xcodes/Resources/Licenses.rtf
@@ -4,22 +4,7 @@
 {\*\expandedcolortbl;;}
 \pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\pardirnatural\partightenfactor0
 
-\f0\fs34 \cf0 Preferences\
-\
-
-\fs26 MIT License\
-\
-Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)\
-\
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\
-\
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\
-\
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\
-\
-\
-
-\fs34 SwiftSoup\
+\f0\fs34 \cf0 SwiftSoup\
 \
 
 \fs26 MIT License\

--- a/Xcodes/XcodesApp.swift
+++ b/Xcodes/XcodesApp.swift
@@ -1,5 +1,4 @@
 import AppKit
-import Preferences
 import Sparkle
 import SwiftUI
 

--- a/Xcodes/XcodesApp.swift
+++ b/Xcodes/XcodesApp.swift
@@ -36,13 +36,7 @@ struct XcodesApp: App {
                     appDelegate.checkForUpdates()
                 }
             }
-            CommandGroup(replacing: .appSettings) {
-                Button("Preferences...") {
-                    showPreferencesWindow()
-                }
-                .keyboardShortcut(KeyEquivalent(","), modifiers: .command)
-            }
-            
+        
             CommandGroup(after: CommandGroupPlacement.newItem) {
                 Button("Refresh") {
                     appState.update()
@@ -72,37 +66,12 @@ struct XcodesApp: App {
                 }
             }
         }
-    }
-    
-    private func showPreferencesWindow() {
-        PreferencesWindowController(
-            panes: [
-                Preferences.Pane(
-                    identifier: .general,
-                    title: "General",
-                    toolbarIcon: NSImage(systemSymbolName: "gearshape", accessibilityDescription: "General")!
-                ) {
-                    GeneralPreferencePane()
-                        .environmentObject(appState)
-                },
-                Preferences.Pane(
-                    identifier: .updates,
-                    title: "Updates",
-                    toolbarIcon: NSImage(systemSymbolName: "arrow.triangle.2.circlepath.circle", accessibilityDescription: "Updates")!
-                ) {
-                    UpdatesPreferencePane()
-                },
-                Preferences.Pane(
-                    identifier: .advanced,
-                    title: "Advanced",
-                    toolbarIcon: NSImage(systemSymbolName: "gearshape.2", accessibilityDescription: "Advanced")!
-                ) {
-                    AdvancedPreferencePane()
-                        .environmentObject(appState)
-                },
-            ]
-        )
-        .show()
+        #if os(macOS)
+        Settings {
+            PreferencesView()
+                .environmentObject(appState)
+        }
+        #endif
     }
 }
 


### PR DESCRIPTION
Fixes #88 

Uses SwiftUI's Settings Scene - https://developer.apple.com/documentation/swiftui/settings Instead of PreferencesWindowController that comes with the `Preferences` add in.

Preferences dependency has been removed. Converted the style with a `PreferencesGroupBoxStyle`, which turned out pretty well. 

Did a quick test for the options and things seems to work. Some awkwardness with InstallHelper as it closes the preferences window automatically, but it works.

![image](https://user-images.githubusercontent.com/1119565/105944552-2542ea00-6029-11eb-9d19-bc1ffd81bcb2.png)

The only annoyance that I couldn't figure out is the advanced view looks to have a different background color, compared to the other views, but I couldn't figure out why. 
