### PR TITLE
Improve how identical builds are represented in the UI

### DIFF
--- a/Xcodes/Backend/AppState.swift
+++ b/Xcodes/Backend/AppState.swift
@@ -450,6 +450,9 @@ class AppState: ObservableObject {
         // Map all of the available versions into Xcode values that join available and installed Xcode data for display.
         var newAllXcodes = adjustedAvailableXcodes
             .filter { availableXcode in
+                // If we don't have the build identifier, don't attempt to filter prerelease versions with identical build identifiers
+                guard !availableXcode.version.buildMetadataIdentifiers.isEmpty else { return true }
+
                 let availableXcodesWithIdenticalBuildIdentifiers = availableXcodes
                     .filter({ $0.version.buildMetadataIdentifiers == availableXcode.version.buildMetadataIdentifiers })
                 
@@ -466,7 +469,10 @@ class AppState: ObservableObject {
                 let identicalBuilds: [Version]
                 let prereleaseAvailableXcodesWithIdenticalBuildIdentifiers = availableXcodes
                     .filter {
-                        $0.version.buildMetadataIdentifiers == availableXcode.version.buildMetadataIdentifiers && !$0.version.prereleaseIdentifiers.isEmpty
+                        return $0.version.buildMetadataIdentifiers == availableXcode.version.buildMetadataIdentifiers &&
+                            !$0.version.prereleaseIdentifiers.isEmpty &&
+                            // If we don't have the build identifier, don't consider this as a potential identical build
+                            !$0.version.buildMetadataIdentifiers.isEmpty
                     }
                 // If this is the release version, add the identical builds to it
                 if !prereleaseAvailableXcodesWithIdenticalBuildIdentifiers.isEmpty, availableXcode.version.prereleaseIdentifiers.isEmpty {

--- a/Xcodes/Backend/AppState.swift
+++ b/Xcodes/Backend/AppState.swift
@@ -464,10 +464,13 @@ class AppState: ObservableObject {
                 })
 
                 let identicalBuilds: [Version]
-                let availableXcodesWithIdenticalBuildIdentifiers = availableXcodes
-                    .filter({ $0.version.buildMetadataIdentifiers == availableXcode.version.buildMetadataIdentifiers })
-                if availableXcodesWithIdenticalBuildIdentifiers.count > 1, availableXcode.version.prereleaseIdentifiers.isEmpty {
-                    identicalBuilds = availableXcodesWithIdenticalBuildIdentifiers.map(\.version)
+                let prereleaseAvailableXcodesWithIdenticalBuildIdentifiers = availableXcodes
+                    .filter {
+                        $0.version.buildMetadataIdentifiers == availableXcode.version.buildMetadataIdentifiers && !$0.version.prereleaseIdentifiers.isEmpty
+                    }
+                // If this is the release version, add the identical builds to it
+                if !prereleaseAvailableXcodesWithIdenticalBuildIdentifiers.isEmpty, availableXcode.version.prereleaseIdentifiers.isEmpty {
+                    identicalBuilds = [availableXcode.version] + prereleaseAvailableXcodesWithIdenticalBuildIdentifiers.map(\.version)
                 } else {
                     identicalBuilds = []
                 }

--- a/Xcodes/Backend/Version+Xcode.swift
+++ b/Xcodes/Backend/Version+Xcode.swift
@@ -50,7 +50,13 @@ public extension Version {
         }
         if !prereleaseIdentifiers.isEmpty {
             base += " " + prereleaseIdentifiers
-                .map { $0.replacingOccurrences(of: "-", with: " ").capitalized.replacingOccurrences(of: "Gm", with: "GM") }
+                .map { identifiers in
+                    identifiers
+                        .replacingOccurrences(of: "-", with: " ")
+                        .capitalized
+                        .replacingOccurrences(of: "Gm", with: "GM")
+                        .replacingOccurrences(of: "Rc", with: "RC")
+                }
                 .joined(separator: " ")
         }
         return base

--- a/Xcodes/Backend/Version+XcodeReleases.swift
+++ b/Xcodes/Backend/Version+XcodeReleases.swift
@@ -25,7 +25,7 @@ extension Version {
                 versionString += ".\(dp)"
             }
         case .gm:
-            versionString += "-GM"
+            break
         case let .gmSeed(gmSeed):
             versionString += "-GM.Seed"
             if gmSeed > 1 {

--- a/Xcodes/Backend/Xcode.swift
+++ b/Xcodes/Backend/Xcode.swift
@@ -6,6 +6,8 @@ import struct XCModel.Compilers
 
 struct Xcode: Identifiable, CustomStringConvertible {
     let version: Version
+    /// Other Xcode versions that have the same build identifier
+    let identicalBuilds: [Version]
     var installState: XcodeInstallState
     let selected: Bool
     let icon: NSImage?
@@ -17,6 +19,7 @@ struct Xcode: Identifiable, CustomStringConvertible {
     
     init(
         version: Version,
+        identicalBuilds: [Version] = [],
         installState: XcodeInstallState,
         selected: Bool,
         icon: NSImage?,
@@ -27,6 +30,7 @@ struct Xcode: Identifiable, CustomStringConvertible {
         downloadFileSize: Int64? = nil
     ) {
         self.version = version
+        self.identicalBuilds = identicalBuilds
         self.installState = installState
         self.selected = selected
         self.icon = icon

--- a/Xcodes/Frontend/XcodeList/InfoPane.swift
+++ b/Xcodes/Frontend/XcodeList/InfoPane.swift
@@ -53,6 +53,7 @@ struct InfoPane: View {
                     Divider()
                     
                     releaseNotes(for: xcode)
+                    identicalBuilds(for: xcode)
                     compatibility(for: xcode)
                     sdks(for: xcode)
                     compilers(for: xcode)
@@ -77,6 +78,34 @@ struct InfoPane: View {
                 .resizable()
                 .frame(width: 32, height: 32)
                 .foregroundColor(.secondary)
+        }
+    }
+    
+    @ViewBuilder
+    private func identicalBuilds(for xcode: Xcode) -> some View {
+        if !xcode.identicalBuilds.isEmpty {
+            VStack(alignment: .leading) {
+                HStack {
+                    Text("Identical Builds")
+                    Image(systemName: "square.fill.on.square.fill")
+                        .foregroundColor(.secondary)
+                        .accessibility(hidden: true)
+                        .help("Sometimes a prerelease and release version are the exact same build. Xcodes will automatically display these versions together.")
+                }
+                .font(.headline)
+                
+                ForEach(xcode.identicalBuilds, id: \.description) { version in
+                    Text("• \(version.appleDescription)")
+                        .font(.subheadline)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityElement()
+            .accessibility(label: Text("Identical Builds"))
+            .accessibility(value: Text(xcode.identicalBuilds.map(\.appleDescription).joined(separator: ", ")))
+            .accessibility(hint: Text("Sometimes a prerelease and release version are the exact same build. Xcodes will automatically display these versions together."))
+        } else {
+            EmptyView()
         }
     }
     

--- a/Xcodes/Frontend/XcodeList/InfoPane.swift
+++ b/Xcodes/Frontend/XcodeList/InfoPane.swift
@@ -11,8 +11,8 @@ struct InfoPane: View {
     @SwiftUI.Environment(\.openURL) var openURL: OpenURLAction
     
     var body: some View {
-        Group {
-            if let xcode = appState.allXcodes.first(where: { $0.id == selectedXcodeID }) {
+        if let xcode = appState.allXcodes.first(where: { $0.id == selectedXcodeID }) {
+            ScrollView {
                 VStack(spacing: 16) {
                     icon(for: xcode)
                     
@@ -61,12 +61,13 @@ struct InfoPane: View {
                     
                     Spacer()
                 }
-            } else {
-                empty
+                .padding()
             }
+            .frame(minWidth: 200, maxWidth: .infinity)
+        } else {
+            empty
+                .frame(minWidth: 200, maxWidth: .infinity)
         }
-        .padding()
-        .frame(minWidth: 200, maxWidth: .infinity)
     }
     
     @ViewBuilder
@@ -212,13 +213,11 @@ struct InfoPane: View {
     
     @ViewBuilder
     private var empty: some View {
-        VStack {
-            Spacer()
-            Text("No Xcode Selected")
-                .font(.title)
-                .foregroundColor(.secondary)
-            Spacer()
-        }
+        Text("No Xcode Selected")
+            .font(.title)
+            .foregroundColor(.secondary)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding()
     }
 }
 

--- a/Xcodes/Frontend/XcodeList/XcodeListView.swift
+++ b/Xcodes/Frontend/XcodeList/XcodeListView.swift
@@ -32,7 +32,7 @@ struct XcodeListView: View {
     
     var body: some View {
         List(visibleXcodes, selection: $selectedXcodeID) { xcode in
-            XcodeListViewRow(xcode: xcode, selected: selectedXcodeID == xcode.id)
+            XcodeListViewRow(xcode: xcode, selected: selectedXcodeID == xcode.id, appState: appState)
         }
     }
 }

--- a/Xcodes/Frontend/XcodeList/XcodeListView.swift
+++ b/Xcodes/Frontend/XcodeList/XcodeListView.swift
@@ -44,6 +44,7 @@ struct XcodeListView_Previews: PreviewProvider {
                 .environmentObject({ () -> AppState in
                     let a = AppState()
                     a.allXcodes = [
+                        Xcode(version: Version("12.0.0+1234A")!, identicalBuilds: [Version("12.0.0+1234A")!, Version("12.0.0-RC+1234A")!], installState: .installed(Path("/Applications/Xcode-12.3.0.app")!), selected: false, icon: nil),
                         Xcode(version: Version("12.3.0")!, installState: .installed(Path("/Applications/Xcode-12.3.0.app")!), selected: true, icon: nil),
                         Xcode(version: Version("12.2.0")!, installState: .notInstalled, selected: false, icon: nil),
                         Xcode(version: Version("12.1.0")!, installState: .installing(.downloading(progress: configure(Progress(totalUnitCount: 100)) { $0.completedUnitCount = 40 })), selected: false, icon: nil),

--- a/Xcodes/Frontend/XcodeList/XcodeListViewRow.swift
+++ b/Xcodes/Frontend/XcodeList/XcodeListViewRow.swift
@@ -3,9 +3,9 @@ import SwiftUI
 import Version
 
 struct XcodeListViewRow: View {
-    @EnvironmentObject var appState: AppState
     let xcode: Xcode
     let selected: Bool
+    let appState: AppState
     
     var body: some View {
         HStack {
@@ -112,29 +112,39 @@ struct XcodeListViewRow_Previews: PreviewProvider {
         Group {
             XcodeListViewRow(
                 xcode: Xcode(version: Version("12.3.0")!, installState: .installed(Path("/Applications/Xcode-12.3.0.app")!), selected: true, icon: nil),
-                selected: false
+                selected: false,
+                appState: AppState()
             )
             
             XcodeListViewRow(
                 xcode: Xcode(version: Version("12.2.0")!, installState: .notInstalled, selected: false, icon: nil),
-                selected: false
+                selected: false,
+                appState: AppState()
             )
             
             XcodeListViewRow(
                 xcode: Xcode(version: Version("12.1.0")!, installState: .installing(.downloading(progress: configure(Progress(totalUnitCount: 100)) { $0.completedUnitCount = 40 })), selected: false, icon: nil),
-                selected: false
+                selected: false,
+                appState: AppState()
             )
             
             XcodeListViewRow(
                 xcode: Xcode(version: Version("12.0.0")!, installState: .installed(Path("/Applications/Xcode-12.3.0.app")!), selected: false, icon: nil),
-                selected: false
+                selected: false,
+                appState: AppState()
             )
             
             XcodeListViewRow(
                 xcode: Xcode(version: Version("12.0.0+1234A")!, installState: .installed(Path("/Applications/Xcode-12.3.0.app")!), selected: false, icon: nil),
-                selected: false
+                selected: false,
+                appState: AppState()
+            )
+            
+            XcodeListViewRow(
+                xcode: Xcode(version: Version("12.0.0+1234A")!, identicalBuilds: [Version("12.0.0-RC+1234A")!], installState: .installed(Path("/Applications/Xcode-12.3.0.app")!), selected: false, icon: nil),
+                selected: false,
+                appState: AppState()
             )
         }
-        .environmentObject(AppState())
     }
 }

--- a/Xcodes/Frontend/XcodeList/XcodeListViewRow.swift
+++ b/Xcodes/Frontend/XcodeList/XcodeListViewRow.swift
@@ -12,8 +12,19 @@ struct XcodeListViewRow: View {
             appIconView(for: xcode)
             
             VStack(alignment: .leading) {
-                Text(verbatim: "\(xcode.description) \(xcode.version.buildMetadataIdentifiersDisplay)")
-                    .font(.body)
+                HStack {
+                    Text(verbatim: "\(xcode.description) \(xcode.version.buildMetadataIdentifiersDisplay)")
+                        .font(.body)
+                    
+                    if !xcode.identicalBuilds.isEmpty {
+                        Image(systemName: "square.fill.on.square.fill")
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                            .accessibility(label: Text("Identical Builds"))
+                            .accessibility(value: Text(xcode.identicalBuilds.map(\.appleDescription).joined(separator: ", ")))
+                            .help("Sometimes a prerelease and release version are the exact same build. Xcodes will automatically display these versions together.")
+                    }
+                }
                 
                 if case let .installed(path) = xcode.installState {
                     Text(verbatim: path.string)

--- a/XcodesTests/AppStateUpdateTests.swift
+++ b/XcodesTests/AppStateUpdateTests.swift
@@ -232,4 +232,30 @@ class AppStateUpdateTests: XCTestCase {
         XCTAssertEqual(subject.allXcodes.map(\.version), [Version("12.4.0+12D4e")!])
         XCTAssertEqual(subject.allXcodes.map(\.identicalBuilds), [[Version("12.4.0+12D4e")!, Version("12.4.0-RC+12D4e")!]])
     }
+    
+    func testIdenticalBuilds_AppleDataSource_DoNotMergeVersionsWithoutBuildIdentifiers() {
+        Current.defaults.string = { key in
+            if key == "dataSource" {
+                return "apple" 
+            } else {
+                return nil
+            }
+        }
+
+        subject.allXcodes = [
+        ]
+        
+        subject.updateAllXcodes(
+            availableXcodes: [
+                AvailableXcode(version: Version("12.4.0")!, url: URL(string: "https://apple.com/xcode.xip")!, filename: "mock.xip", releaseDate: nil),
+                AvailableXcode(version: Version("12.3.0-RC")!, url: URL(string: "https://apple.com/xcode.xip")!, filename: "mock.xip", releaseDate: nil),
+            ], 
+            installedXcodes: [
+            ], 
+            selectedXcodePath: nil
+        )
+        
+        XCTAssertEqual(subject.allXcodes.map(\.version), [Version("12.4.0")!, Version("12.3.0-RC")!])
+        XCTAssertEqual(subject.allXcodes.map(\.identicalBuilds), [[], []])
+    }
 }

--- a/XcodesTests/AppStateUpdateTests.swift
+++ b/XcodesTests/AppStateUpdateTests.swift
@@ -148,6 +148,32 @@ class AppStateUpdateTests: XCTestCase {
         XCTAssertEqual(subject.allXcodes.map(\.identicalBuilds), [[Version("12.4.0+12D4e")!, Version("12.4.0-RC+12D4e")!]])
     }
     
+    func testIdenticalBuilds_DoNotMergeReleaseVersions() {
+        Current.defaults.string = { key in
+            if key == "dataSource" {
+                return "xcodeReleases" 
+            } else {
+                return nil
+            }
+        }
+
+        subject.allXcodes = [
+        ]
+        
+        subject.updateAllXcodes(
+            availableXcodes: [
+                AvailableXcode(version: Version("3.2.3+10M2262")!, url: URL(string: "https://apple.com/xcode.xip")!, filename: "mock.xip", releaseDate: nil),
+                AvailableXcode(version: Version("3.2.3+10M2262")!, url: URL(string: "https://apple.com/xcode.xip")!, filename: "mock.xip", releaseDate: nil),
+            ], 
+            installedXcodes: [
+            ], 
+            selectedXcodePath: nil
+        )
+        
+        XCTAssertEqual(subject.allXcodes.map(\.version), [Version("3.2.3+10M2262")!, Version("3.2.3+10M2262")!])
+        XCTAssertEqual(subject.allXcodes.map(\.identicalBuilds), [[], []])
+    }
+    
     func testIdenticalBuilds_KeepsReleaseVersion_WithPrereleaseInstalled() {
         Current.defaults.string = { key in
             if key == "dataSource" {

--- a/XcodesTests/AppStateUpdateTests.swift
+++ b/XcodesTests/AppStateUpdateTests.swift
@@ -145,6 +145,7 @@ class AppStateUpdateTests: XCTestCase {
         )
         
         XCTAssertEqual(subject.allXcodes.map(\.version), [Version("12.4.0+12D4e")!])
+        XCTAssertEqual(subject.allXcodes.map(\.identicalBuilds), [[Version("12.4.0+12D4e")!, Version("12.4.0-RC+12D4e")!]])
     }
     
     func testIdenticalBuilds_KeepsReleaseVersion_WithPrereleaseInstalled() {
@@ -203,15 +204,6 @@ class AppStateUpdateTests: XCTestCase {
         )
         
         XCTAssertEqual(subject.allXcodes.map(\.version), [Version("12.4.0+12D4e")!])
-    }
-    
-    func testFilterReleasesThatMatchPrereleases() {
-        let result = subject.filterPrereleasesThatMatchReleaseBuildMetadataIdentifiers(
-            [
-                AvailableXcode(version: Version("12.3.0+12C33")!, url: URL(string: "https://apple.com")!, filename: "Xcode_12.3.xip", releaseDate: nil),
-                AvailableXcode(version: Version("12.3.0-RC+12C33")!, url: URL(string: "https://apple.com")!, filename: "Xcode_12.3_RC_1.xip", releaseDate: nil),
-            ]
-        )
-        XCTAssertEqual(result.map(\.version), [Version("12.3.0+12C33")])
+        XCTAssertEqual(subject.allXcodes.map(\.identicalBuilds), [[Version("12.4.0+12D4e")!, Version("12.4.0-RC+12D4e")!]])
     }
 }


### PR DESCRIPTION
This change attempts to improve how different versions with the exact same build identifier are represented in the UI.

Background: Sometimes the last prerelease version (for example 12.4 Release Candidate) and the release version (12.4) are the exact same and have the same build identifier as a result (12D4e in this case.) While we _could_ just do the easy thing and have independent rows in the list for each version, this makes it difficult to determine which versions are installed. I also doubt that anyone would really want more than one version installed when they're the exact same build. If anything, most users would want to know when they're the exact same so that they can _avoid_ installing another version.

Through version 1.0.3 (4) I'd attempted to handle this by filtering out prerelease versions that had the same build identifier as a release version. For a couple reasons this ended up being confusing, and resulted in issue #90.

The main change here is instead of filtering out versions, keep the release version and associate the other prerelease versions with identical build identifiers with it. These identical builds can then be represented in the list and info pane.

One of the issues before was that there is some "adjusting" logic that tries to improve the data we have about available and installed Xcode versions. This was originally added because of shortcomings of scraping the Apple Developer site. I kept this code even after we added the Xcode Releases data source, and while it was mostly benign it made this identical build ambiguity worse. This PR changes this "adjusting" logic to only apply to the Apple data source instead. It also now treats what Xcode Release identifies as GM versions (which are final releases, as opposed to GM seeds) as release versions without any prerelease identifiers.

The UI changes that I ended up with are an icon in the list row and a new section in the info pane. I had tested out an expanding row that revealed the identical build versions, which I think is valuable, but I'm finding too many issues with the macOS List implementation (performance and memory leaks) and I'm concerned about making the row views more complex. I'd like to revisit this design in the future, though. Instead a single icon is added with some help text. For both of the new views I made sure to use some accessibility modifiers so they both read reasonably well with VoiceOver when testing with the Accessibility Inspector. I didn't go any further than the new UI, but I think we should take a pass on the rest of the app soon.

<img width="940" alt="Screen Shot 2021-02-04 at 9 16 28 PM" src="https://user-images.githubusercontent.com/594059/106989049-8015c900-672e-11eb-9af1-374bc23440dc.png">

_Example: note that I have 12.4 RC installed, and the row for the final release is appearing as installed with the correct path. The row has the identical builds indicator, and both versions are listed under the new heading in the info pane._

---
Closes #90