### PR TITLE
Remove info pane from split view instead of hiding it

### DIFF
--- a/Xcodes/Frontend/MainWindow.swift
+++ b/Xcodes/Frontend/MainWindow.swift
@@ -24,19 +24,11 @@ struct MainWindow: View {
                           primaryButton: .destructive(Text("Uninstall"), action: { self.appState.uninstall(id: xcode.id) }),
                           secondaryButton: .cancel(Text("Cancel")))
                 }
-            InfoPane(selectedXcodeID: selectedXcodeID)
-                .frame(minWidth: 300, maxWidth: .infinity)
-                .frame(width: isShowingInfoPane ? nil : 0)
-                .isHidden(!isShowingInfoPane)
-                // This alert isn't intentionally placed here, 
-                // just trying to put it in a unique part of the hierarchy 
-                // since you can't have more than one in the same spot.
-                .alert(item: $appState.xcodeBeingConfirmedForInstallCancellation) { xcode in
-                    Alert(title: Text("Are you sure you want to stop the installation of Xcode \(xcode.description)?"),
-                          message: Text("Any progress will be discarded."),
-                          primaryButton: .destructive(Text("Stop Installation"), action: { self.appState.cancelInstall(id: xcode.id) }),
-                          secondaryButton: .cancel(Text("Cancel")))
-                }
+            
+            if isShowingInfoPane {
+                InfoPane(selectedXcodeID: selectedXcodeID)
+                    .frame(minWidth: 300, maxWidth: .infinity)
+            }
         }
         .mainToolbar(
             category: $category,
@@ -50,6 +42,17 @@ struct MainWindow: View {
             secondFactorView(appState.secondFactorData!)
                 .environmentObject(appState)
         }
+        // This overlay is only here to work around the one-alert-per-view limitation
+        .overlay(
+            Color.clear
+                // This particular alert could be added specifically to InstallationStepView and CancelInstallButton _except_ for when CancelInstallButton is used in the Xcode CommandMenu, so it's here for now. 
+                .alert(item: $appState.xcodeBeingConfirmedForInstallCancellation) { xcode in
+                    Alert(title: Text("Are you sure you want to stop the installation of Xcode \(xcode.description)?"),
+                          message: Text("Any progress will be discarded."),
+                          primaryButton: .destructive(Text("Stop Installation"), action: { self.appState.cancelInstall(id: xcode.id) }),
+                          secondaryButton: .cancel(Text("Cancel")))
+                }
+        )
         // This overlay is only here to work around the one-alert-per-view limitation
         .overlay(
             Color.clear


### PR DESCRIPTION
When the info pane was simply hidden, the split view would still allow you to resize the remaining split (note the cursor in the first recording), which resulted in weird behaviour. Instead, just remove the info pane split and then the split view doesn't let you resize. Had to move where the global "cancel install" alert is in the view hierarchy as a result, because it might have to be presented even if the info pane isn't part of the view hierarchy.

I tried changing the alert so it wasn't a part of the main window at all, and was instead local to the buttons that triggered its presentation, and this worked for all but the case where the CancelInstallButton was used from the Xcode menu. So for now I left it close to where it already was.

Before:

https://user-images.githubusercontent.com/594059/107133822-81b7cc00-68a9-11eb-8477-6c2a7918db94.mp4

After:

https://user-images.githubusercontent.com/594059/107133832-89777080-68a9-11eb-974c-d72e70767f31.mp4

