### PR TITLE
Moves the .help for the ProgressIndicator so it refreshes with the fraction change

### DIFF
--- a/Xcodes/Frontend/Common/ObservingProgressIndicator.swift
+++ b/Xcodes/Frontend/Common/ObservingProgressIndicator.swift
@@ -42,6 +42,7 @@ public struct ObservingProgressIndicator: View {
             isIndeterminate: progress.progress.isIndeterminate,
             style: style
         )
+        .help("Dowloading: \(Int((progress.progress.fractionCompleted * 100)))% complete")
     }
 }
 

--- a/Xcodes/Frontend/Common/ObservingProgressIndicator.swift
+++ b/Xcodes/Frontend/Common/ObservingProgressIndicator.swift
@@ -42,7 +42,7 @@ public struct ObservingProgressIndicator: View {
             isIndeterminate: progress.progress.isIndeterminate,
             style: style
         )
-        .help("Dowloading: \(Int((progress.progress.fractionCompleted * 100)))% complete")
+        .help("Downloading: \(Int((progress.progress.fractionCompleted * 100)))% complete")
     }
 }
 

--- a/Xcodes/Frontend/XcodeList/InstallationStepView.swift
+++ b/Xcodes/Frontend/XcodeList/InstallationStepView.swift
@@ -17,7 +17,6 @@ struct InstallationStepView: View {
                     controlSize: .small,
                     style: .spinning
                 )
-                .help("Dowloading: \(Int((progress.fractionCompleted * 100)))% complete")
             case .unarchiving, .moving, .trashingArchive, .checkingSecurity, .finishing:
                 ProgressView()
                     .scaleEffect(0.5)


### PR DESCRIPTION
Fixes #93 

Move the `.help` away from the StepView into the ProgressIndicator so that it can catch the fraction completed events.  