### PR TITLE
Auto Install Xcode if wanted

### DIFF
--- a/Xcodes/Backend/AppState+Update.swift
+++ b/Xcodes/Backend/AppState+Update.swift
@@ -6,11 +6,20 @@ import SwiftSoup
 import struct XCModel.Xcode
 
 extension AppState {
+    
+    var isReadyForUpdate: Bool {
+        guard let lastUpdated = Current.defaults.date(forKey: "lastUpdated"),
+          // This is bad date math but for this use case it doesn't need to be exact
+          lastUpdated < Current.date().addingTimeInterval(-60 * 60 * 5)
+        else {
+            return false
+       }
+        return true
+    }
+    
     func updateIfNeeded() {
         guard
-            let lastUpdated = Current.defaults.date(forKey: "lastUpdated"),
-            // This is bad date math but for this use case it doesn't need to be exact
-            lastUpdated < Current.date().addingTimeInterval(-60 * 60 * 24) 
+            isReadyForUpdate
         else { 
             updatePublisher = updateSelectedXcodePath()
                 .sink(

--- a/Xcodes/Frontend/Preferences/UpdatesPreferencePane.swift
+++ b/Xcodes/Frontend/Preferences/UpdatesPreferencePane.swift
@@ -5,29 +5,51 @@ import SwiftUI
 struct UpdatesPreferencePane: View {
     @StateObject var updater = ObservableUpdater()
     
+    @AppStorage("autoInstallation") var autoInstallationType: AutoInstallationType = .none
+    
     var body: some View {
-        GroupBox(label: Text("Updates")) {
-            VStack(alignment: .leading) {
-                Toggle(
-                    "Automatically check for app updates",
-                    isOn: $updater.automaticallyChecksForUpdates
-                )
-                
-                Toggle(
-                    "Include prerelease app versions",
-                    isOn: $updater.includePrereleaseVersions
-                )
-                                    
-                Button("Check Now") {
-                    SUUpdater.shared()?.checkForUpdates(nil)
+        VStack(alignment: .leading, spacing: 20) {
+            GroupBox(label: Text("Versions")) {
+                VStack(alignment: .leading) {
+                    Toggle(
+                        "Automatically install new versions of Xcode",
+                        isOn: $autoInstallationType.isAutoInstalling
+                    )
+                    
+                    Toggle(
+                        "Include prerelease/beta versions",
+                        isOn: $autoInstallationType.isAutoInstallingBeta
+                    )
                 }
-
-                Text("Last checked: \(lastUpdatedString)")
-                    .font(.footnote)
+                .fixedSize(horizontal: false, vertical: true)
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
+            .groupBoxStyle(PreferencesGroupBoxStyle())
+            
+            Divider()
+            
+            GroupBox(label: Text("Xcodes.app Updates")) {
+                VStack(alignment: .leading) {
+                    Toggle(
+                        "Automatically check for app updates",
+                        isOn: $updater.automaticallyChecksForUpdates
+                    )
+                    
+                    Toggle(
+                        "Include prerelease app versions",
+                        isOn: $updater.includePrereleaseVersions
+                    )
+                    
+                    Button("Check Now") {
+                        SUUpdater.shared()?.checkForUpdates(nil)
+                    }
+                    
+                    Text("Last checked: \(lastUpdatedString)")
+                        .font(.footnote)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .groupBoxStyle(PreferencesGroupBoxStyle())
         }
-        .groupBoxStyle(PreferencesGroupBoxStyle())
         .frame(width: 400)
     }
     


### PR DESCRIPTION
Whenever the available Xcodes gets update, check to see if the user wants to auto install it. If so, do it.

Inside of Preferences > Updates, there is an option to auto install the latest xcode version or the latest beta version. 

![image](https://user-images.githubusercontent.com/1119565/110253429-e5d4bb00-7f4f-11eb-9bbb-0e53f41184d6.png)

I also added in a Timer that runs every 6 hours. This is to get around that if the user has the app open, but never goes back into it, it should still try and update. I've updated the auto refresh check to every 5 hours before it's invalid.

____
Closes #99