### PR TITLE
Updates estimated time on info pane to 2 lines for better readability

### DIFF
--- a/Xcodes/Backend/Progress+.swift
+++ b/Xcodes/Backend/Progress+.swift
@@ -2,6 +2,9 @@ import os.log
 import Foundation
 
 extension Progress {
+    var xcodesLocalizedDescription: String {
+        return localizedAdditionalDescription.replacingOccurrences(of: " — ", with: "\n")
+    }
     func updateFromAria2(string: String) {
             
         let range = NSRange(location: 0, length: string.utf16.count)

--- a/Xcodes/Frontend/Common/ObservingProgressIndicator.swift
+++ b/Xcodes/Frontend/Common/ObservingProgressIndicator.swift
@@ -48,8 +48,8 @@ public struct ObservingProgressIndicator: View {
             )
             .help("Downloading: \(Int((progress.progress.fractionCompleted * 100)))% complete")
             
-            if showsAdditionalDescription, progress.progress.localizedAdditionalDescription.isEmpty == false { 
-                Text(progress.progress.localizedAdditionalDescription)
+            if showsAdditionalDescription, progress.progress.xcodesLocalizedDescription.isEmpty == false {
+                Text(progress.progress.xcodesLocalizedDescription)
                     .font(.subheadline)
                     .foregroundColor(.secondary)
             }


### PR DESCRIPTION
Closes #113 

Adds a line break before the estimated time remaining

Before: 
![image](https://user-images.githubusercontent.com/1119565/110253909-4e249c00-7f52-11eb-842f-ffd5bc87e48f.png)

After: 
![image](https://user-images.githubusercontent.com/1119565/110253876-259ca200-7f52-11eb-9088-ebbd2cc3e9d8.png)
