### PR TITLE
Disable aria2 as an option for M1 macs

### DIFF
--- a/Xcodes/Backend/AppState+Install.swift
+++ b/Xcodes/Backend/AppState+Install.swift
@@ -105,9 +105,11 @@ extension AppState {
         // aria2 downloads directly to the destination (instead of into /tmp first) so we need to make sure that the download isn't incomplete
         let aria2DownloadMetadataPath = expectedArchivePath.parent/(expectedArchivePath.basename() + ".aria2")
         var aria2DownloadIsIncomplete = false
+        #if arch(x86_64)
         if case .aria2 = downloader, aria2DownloadMetadataPath.exists {
             aria2DownloadIsIncomplete = true
         }
+        #endif
         if Current.files.fileExistsAtPath(expectedArchivePath.string), aria2DownloadIsIncomplete == false {
             Logger.appState.info("Found existing archive that will be used for installation at \(expectedArchivePath).")
             return Just(expectedArchivePath.url)
@@ -117,6 +119,7 @@ extension AppState {
         else {
             let destination = Path.xcodesApplicationSupport/"Xcode-\(availableXcode.version).\(availableXcode.filename.suffix(fromLast: "."))"
             switch downloader {
+            #if arch(x86_64)
             case .aria2:
                 let aria2Path = Path(url: Bundle.main.url(forAuxiliaryExecutable: "aria2c")!)!
                 return downloadXcodeWithAria2(
@@ -125,6 +128,7 @@ extension AppState {
                     aria2Path: aria2Path,
                     progressChanged: progressChanged
                 )
+            #endif
             case .urlSession:
                 return downloadXcodeWithURLSession(
                     availableXcode,

--- a/Xcodes/Backend/Downloader.swift
+++ b/Xcodes/Backend/Downloader.swift
@@ -2,7 +2,9 @@ import Foundation
 import Path
 
 public enum Downloader: String, CaseIterable, Identifiable, CustomStringConvertible {
+    #if arch(x86_64)
     case aria2
+    #endif
     case urlSession
     
     public var id: Self { self }
@@ -10,7 +12,9 @@ public enum Downloader: String, CaseIterable, Identifiable, CustomStringConverti
     public var description: String {
         switch self {
         case .urlSession: return "URLSession"
+        #if arch(x86_64)
         case .aria2: return "aria2"
+        #endif
         }
     }
 }

--- a/Xcodes/Frontend/Preferences/AdvancedPreferencePane.swift
+++ b/Xcodes/Frontend/Preferences/AdvancedPreferencePane.swift
@@ -4,7 +4,13 @@ import SwiftUI
 struct AdvancedPreferencePane: View {
     @EnvironmentObject var appState: AppState
     @AppStorage("dataSource") var dataSource: DataSource = .xcodeReleases
+    #if arch(arm64)
+    // aria2 is not yet compatible on M1 silicon
+    @AppStorage("downloader") var downloader: Downloader = .urlSession
+    #elseif arch(x86_64)
     @AppStorage("downloader") var downloader: Downloader = .aria2
+    #endif
+    
     
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
@@ -87,11 +93,19 @@ struct AdvancedPreferencePane: View {
     }
     
     private var downloaderFootnote: NSAttributedString {
+        #if arch(arm64)
+        let string = """
+        URLSession is the default Apple API for making URL requests.
+
+        aria2 is also offered as an option on Intel Macs, but is not yet compatible with M1 silicon.
+        """
+        #elseif arch(x86_64)
         let string = """
         aria2 uses up to 16 connections to download Xcode 3-5x faster than URLSession. It's bundled as an executable along with its source code within Xcodes to comply with its GPLv2 license.
 
         URLSession is the default Apple API for making URL requests.
         """
+        #endif
         let attributedString = NSMutableAttributedString(
             string: string, 
             attributes: [


### PR DESCRIPTION
One possible solution for issue #117 where only the URLSession downloader is made available.

I'm not fully convinced this is a good solution (the best thing would be a universal or arm64 binary of aria2), but this does make Xcodes.app work on M1 Macs.