### PR TITLE
Show sign in errors inline on sign in view

### DIFF
--- a/Xcodes/Backend/AppState.swift
+++ b/Xcodes/Backend/AppState.swift
@@ -127,6 +127,7 @@ class AppState: ObservableObject {
     }
     
     func signIn(username: String, password: String) {
+        authError = nil
         signIn(username: username, password: password)
             .sink(
                 receiveCompletion: { _ in }, 

--- a/Xcodes/Frontend/MainWindow.swift
+++ b/Xcodes/Frontend/MainWindow.swift
@@ -133,6 +133,7 @@ struct MainWindow: View {
             .padding()
         } else {
             SignInCredentialsView()
+                .frame(width: 400)
         }
     }
 }

--- a/Xcodes/Frontend/SignIn/SignInCredentialsView.swift
+++ b/Xcodes/Frontend/SignIn/SignInCredentialsView.swift
@@ -14,30 +14,42 @@ struct SignInCredentialsView: View {
                 Text("Apple ID:")
                     .frame(minWidth: 100, alignment: .trailing)
                 TextField("example@icloud.com", text: $username)
-                    .frame(width: 250)
             }
             HStack {
                 Text("Password:")
                     .frame(minWidth: 100, alignment: .trailing)
                 SecureField("Required", text: $password)
-                    .frame(width: 250)
+            }
+            if appState.authError != nil {
+                HStack {
+                    Text("")
+                        .frame(minWidth: 100)
+                    Text(appState.authError?.legibleLocalizedDescription ?? "")
+                        .fixedSize(horizontal: false, vertical: true)
+                        .foregroundColor(.red)
+                }
             }
             
             HStack {
                 Spacer()
-                Button("Cancel") { appState.presentedSheet = nil }
-                    .keyboardShortcut(.cancelAction)
-                ProgressButton(isInProgress: appState.isProcessingAuthRequest,
-                               action: { appState.signIn(username: username, password: password) }) {
-                    Text("Next")
+                Button("Cancel") {
+                    appState.authError = nil
+                    appState.presentedSheet = nil
                 }
+                    .keyboardShortcut(.cancelAction)
+                ProgressButton(
+                    isInProgress: appState.isProcessingAuthRequest,
+                    action: { appState.signIn(username: username, password: password) },
+                    label: {
+                        Text("Next")
+                    }
+                )
                 .disabled(username.isEmpty || password.isEmpty)
                 .keyboardShortcut(.defaultAction)
             }
             .frame(height: 25)
         }
         .padding()
-        .emittingError($appState.authError, recoveryHandler: { _ in })
     }
 }
 
@@ -45,5 +57,6 @@ struct SignInCredentialsView_Previews: PreviewProvider {
     static var previews: some View {
         SignInCredentialsView()
             .environmentObject(AppState())
+            .previewLayout(.sizeThatFits)
     }
 }


### PR DESCRIPTION
### What's changed
- Removed the functionality where authentication errors would present an alert
- Added an inline error message to the sign in view for authentication errors
    <img width="453" alt="Screen Shot 2021-05-01 at 9 14 32 AM" src="https://user-images.githubusercontent.com/1420670/116786822-07d55000-aa5e-11eb-95d9-220451347c85.png">

- Handle the case where authentication responds with an account locked error
   <img width="447" alt="Screen Shot 2021-05-01 at 9 14 44 AM" src="https://user-images.githubusercontent.com/1420670/116786825-0ad04080-aa5e-11eb-806c-e9b274886fe1.png">

### How to test
- From an unauthenticated state open up the sign in view either from preferences or the icon in the menu bar
- Fill in your username but provide an incorrect password
- You should see an inline error message "Invalid username and password combination"
- Tapping cancel or next should clear this error message
- If you input a username that is common/short/not an email address like "test" the app will now show a proper error message for account locked. Previously this would generate an alert of the form "Received an unexpected sign in response."
