### PR TITLE
only present a single alert at time

### DIFF
--- a/Xcodes.xcodeproj/project.pbxproj
+++ b/Xcodes.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		536CFDD2263C94DE00026CE0 /* SignedInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 536CFDD1263C94DE00026CE0 /* SignedInView.swift */; };
 		536CFDD4263C9A8000026CE0 /* XcodesSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 536CFDD3263C9A8000026CE0 /* XcodesSheet.swift */; };
+		53CBAB2C263DCC9100410495 /* XcodesAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53CBAB2B263DCC9100410495 /* XcodesAlert.swift */; };
 		63EAA4EB259944450046AB8F /* ProgressButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63EAA4EA259944450046AB8F /* ProgressButton.swift */; };
 		CA11E7BA2598476C00D2EE1C /* XcodeCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA11E7B92598476C00D2EE1C /* XcodeCommands.swift */; };
 		CA2518EC25A7FF2B00F08414 /* AppStateUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2518EB25A7FF2B00F08414 /* AppStateUpdateTests.swift */; };
@@ -160,6 +161,7 @@
 /* Begin PBXFileReference section */
 		536CFDD1263C94DE00026CE0 /* SignedInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignedInView.swift; sourceTree = "<group>"; };
 		536CFDD3263C9A8000026CE0 /* XcodesSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcodesSheet.swift; sourceTree = "<group>"; };
+		53CBAB2B263DCC9100410495 /* XcodesAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcodesAlert.swift; sourceTree = "<group>"; };
 		63EAA4EA259944450046AB8F /* ProgressButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressButton.swift; sourceTree = "<group>"; };
 		CA11E7B92598476C00D2EE1C /* XcodeCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcodeCommands.swift; sourceTree = "<group>"; };
 		CA2518EB25A7FF2B00F08414 /* AppStateUpdateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateUpdateTests.swift; sourceTree = "<group>"; };
@@ -312,6 +314,7 @@
 				63EAA4EA259944450046AB8F /* ProgressButton.swift */,
 				CA452BAF259FD9770072DFA4 /* ProgressIndicator.swift */,
 				536CFDD3263C9A8000026CE0 /* XcodesSheet.swift */,
+				53CBAB2B263DCC9100410495 /* XcodesAlert.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -783,6 +786,7 @@
 				CABFA9C52592EEEA00380FEE /* FileManager+.swift in Sources */,
 				CABFA9CD2592EEEA00380FEE /* Foundation.swift in Sources */,
 				CA9FF8872595607900E47BAF /* InstalledXcode.swift in Sources */,
+				53CBAB2C263DCC9100410495 /* XcodesAlert.swift in Sources */,
 				CA42DD6E25AEA8B200BC0B0C /* Logger.swift in Sources */,
 				CA61A6E0259835580008926E /* Xcode.swift in Sources */,
 				CAE4247F259A666100B8B246 /* MainWindow.swift in Sources */,

--- a/Xcodes/Backend/AppState+Install.swift
+++ b/Xcodes/Backend/AppState+Install.swift
@@ -207,6 +207,7 @@ extension AppState {
                             .handleEvents(receiveCompletion: { [unowned self] completion in
                                 if case let .failure(error) = completion {
                                     self.error = error
+                                    self.presentedAlert = .generic(title: "Unable to install archived Xcode", message: error.legibleLocalizedDescription)
                                 }
                             })
                             .catch { _ in
@@ -343,6 +344,7 @@ extension AppState {
                 receiveCompletion: { completion in
                     if case let .failure(error) = completion {
                         self.error = error
+                        self.presentedAlert = .generic(title: "Unable to perform post install steps", message: error.legibleLocalizedDescription)
                     }
                 }, 
                 receiveValue: {}
@@ -395,6 +397,7 @@ extension AppState {
                         )
                     }
                 }
+                self.presentedAlert = .privilegedHelper
             }
 
             return helperInstallConsentSubject

--- a/Xcodes/Backend/AppState+Update.swift
+++ b/Xcodes/Backend/AppState+Update.swift
@@ -4,6 +4,7 @@ import Path
 import Version
 import SwiftSoup
 import struct XCModel.Xcode
+import AppleAPI
 
 extension AppState {
     
@@ -43,8 +44,11 @@ extension AppState {
                 receiveCompletion: { [unowned self] completion in
                     switch completion {
                     case let .failure(error):
-                        self.error = error
-                        self.presentedAlert = .generic(title: "Unable to update selected Xcode", message: error.legibleLocalizedDescription)
+                        // Prevent setting the app state error if it is an invalid session, we will present the sign in view instead
+                        if error as? AuthenticationError != .invalidSession {
+                            self.error = error
+                            self.presentedAlert = .generic(title: "Unable to update selected Xcode", message: error.legibleLocalizedDescription)
+                        }
                     case .finished:
                         Current.defaults.setDate(Current.date(), forKey: "lastUpdated")
                     }

--- a/Xcodes/Backend/AppState+Update.swift
+++ b/Xcodes/Backend/AppState+Update.swift
@@ -44,6 +44,7 @@ extension AppState {
                     switch completion {
                     case let .failure(error):
                         self.error = error
+                        self.presentedAlert = .generic(title: "Unable to update selected Xcode", message: error.legibleLocalizedDescription)
                     case .finished:
                         Current.defaults.setDate(Current.date(), forKey: "lastUpdated")
                     }

--- a/Xcodes/Backend/AppState.swift
+++ b/Xcodes/Backend/AppState.swift
@@ -42,7 +42,7 @@ class AppState: ObservableObject {
     @Published var isProcessingAuthRequest = false
     @Published var secondFactorData: SecondFactorData?
     @Published var xcodeBeingConfirmedForUninstallation: Xcode?
-    @Published var xcodeBeingConfirmedForInstallCancellation: Xcode?
+    @Published var presentedAlert: XcodesAlert?
     @Published var helperInstallState: HelperInstallState = .notInstalled
     /// Whether the user is being prepared for the helper installation alert with an explanation.
     /// This closure will be performed after the user chooses whether or not to proceed.
@@ -253,6 +253,7 @@ class AppState: ObservableObject {
                 guard userConsented else { return }
                 self.installHelperIfNecessary(shouldPrepareUserForHelperInstallation: false) 
             }
+            presentedAlert = .privilegedHelper
             return
         }
         
@@ -261,6 +262,7 @@ class AppState: ObservableObject {
                 receiveCompletion: { [unowned self] completion in
                     if case let .failure(error) = completion {
                         self.error = error
+                        self.presentedAlert = .generic(title: "Unable to install helper", message: error.legibleLocalizedDescription)
                     }
                 }, 
                 receiveValue: {}
@@ -338,6 +340,7 @@ class AppState: ObservableObject {
                         // Prevent setting the app state error if it is an invalid session, we will present the sign in view instead
                         if error as? AuthenticationError != .invalidSession {
                             self.error = error
+                            self.presentedAlert = .generic(title: "Unable to install Xcode", message: error.legibleLocalizedDescription)
                         }
                         if let index = self.allXcodes.firstIndex(where: { $0.id == id }) { 
                             self.allXcodes[index].installState = .notInstalled
@@ -381,6 +384,7 @@ class AppState: ObservableObject {
                 receiveCompletion: { [unowned self] completion in
                     if case let .failure(error) = completion {
                         self.error = error
+                        self.presentedAlert = .generic(title: "Unable to uninstall Xcode", message: error.legibleLocalizedDescription)
                     }
                     self.uninstallPublisher = nil
                 },
@@ -412,6 +416,7 @@ class AppState: ObservableObject {
                 guard userConsented else { return }
                 self.select(id: id, shouldPrepareUserForHelperInstallation: false) 
             }
+            presentedAlert = .privilegedHelper
             return
         }
 
@@ -431,6 +436,7 @@ class AppState: ObservableObject {
                 receiveCompletion: { [unowned self] completion in
                     if case let .failure(error) = completion {
                         self.error = error
+                        self.presentedAlert = .generic(title: "Unable to select Xcode", message: error.legibleLocalizedDescription)
                     }
                     self.selectPublisher = nil
                 },

--- a/Xcodes/Backend/XcodeCommands.swift
+++ b/Xcodes/Backend/XcodeCommands.swift
@@ -61,7 +61,7 @@ struct CancelInstallButton: View {
     
     private func cancelInstall() {
         guard let xcode = xcode else { return }
-        appState.xcodeBeingConfirmedForInstallCancellation = xcode
+        appState.presentedAlert = .cancelInstall(xcode: xcode)
     }
 }
 

--- a/Xcodes/Frontend/Common/XcodesAlert.swift
+++ b/Xcodes/Frontend/Common/XcodesAlert.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+enum XcodesAlert: Identifiable {
+    case cancelInstall(xcode: Xcode)
+    case privilegedHelper
+    case generic(title: String, message: String)
+
+    var id: Int {
+        switch self {
+        case .cancelInstall: return 1
+        case .privilegedHelper: return 2
+        case .generic: return 3
+        }
+    }
+}

--- a/Xcodes/Frontend/XcodeList/XcodeListViewRow.swift
+++ b/Xcodes/Frontend/XcodeList/XcodeListViewRow.swift
@@ -112,7 +112,7 @@ struct XcodeListViewRow: View {
             InstallationStepRowView(
                 installationStep: installationStep,
                 highlighted: selected,
-                cancel: { appState.xcodeBeingConfirmedForInstallCancellation = xcode }
+                cancel: { appState.presentedAlert = .cancelInstall(xcode: xcode) }
             )
         }
     }


### PR DESCRIPTION
Closes #128 

### Whats changed
Refactored how alerts are presented so its not possible to present multiple alerts at once. The previous implementation using overlays was causing an alert to be displayed anytime the parent view got refreshed.

### How to test
One interesting way to test this is to change the Run configuration from Debug to Test (in Edit Scheme). This will cause an issue where privelidged helper cannot install.
- Running a build using Test you can then try and switch Xcode versions either with the checkmark icon in the list, or using "Make active" button in the info panel when an installed version of Xcode is selected.
- After tapping Install and providing account credentials to the helper you will see an error alert 
    <img width="284" alt="Screen Shot 2021-05-01 at 12 56 57 PM" src="https://user-images.githubusercontent.com/1420670/116792256-b7211f80-aa7c-11eb-9af6-529e750eea2a.png">
- Dismiss this alert and you should no longer see a duplicate error alert pop up