### PR TITLE
Enhancement: Add Xcode release date to info pane in Xcodes.app

### DIFF
--- a/Xcodes/Backend/AppState.swift
+++ b/Xcodes/Backend/AppState.swift
@@ -522,6 +522,7 @@ class AppState: ObservableObject {
                     icon: (installedXcode?.path.string).map(NSWorkspace.shared.icon(forFile:)),
                     requiredMacOSVersion: availableXcode.requiredMacOSVersion,
                     releaseNotesURL: availableXcode.releaseNotesURL,
+                    releaseDate: availableXcode.releaseDate,
                     sdks: availableXcode.sdks,
                     compilers: availableXcode.compilers,
                     downloadFileSize: availableXcode.fileSize

--- a/Xcodes/Backend/Xcode.swift
+++ b/Xcodes/Backend/Xcode.swift
@@ -13,6 +13,7 @@ struct Xcode: Identifiable, CustomStringConvertible {
     let icon: NSImage?
     let requiredMacOSVersion: String?
     let releaseNotesURL: URL?
+    let releaseDate: Date?
     let sdks: SDKs?
     let compilers: Compilers?
     let downloadFileSize: Int64?
@@ -25,6 +26,7 @@ struct Xcode: Identifiable, CustomStringConvertible {
         icon: NSImage?,
         requiredMacOSVersion: String? = nil,
         releaseNotesURL: URL? = nil,
+        releaseDate: Date? = nil,
         sdks: SDKs? = nil,
         compilers: Compilers? = nil,
         downloadFileSize: Int64? = nil
@@ -36,6 +38,7 @@ struct Xcode: Identifiable, CustomStringConvertible {
         self.icon = icon
         self.requiredMacOSVersion = requiredMacOSVersion
         self.releaseNotesURL = releaseNotesURL
+        self.releaseDate = releaseDate
         self.sdks = sdks
         self.compilers = compilers
         self.downloadFileSize = downloadFileSize

--- a/Xcodes/Frontend/InfoPane/InfoPane.swift
+++ b/Xcodes/Frontend/InfoPane/InfoPane.swift
@@ -55,6 +55,7 @@ struct InfoPane: View {
 
                     Group{
                         releaseNotes(for: xcode)
+                        releaseDate(for: xcode)
                         identicalBuilds(for: xcode)
                         compatibility(for: xcode)
                         sdks(for: xcode)
@@ -107,6 +108,22 @@ struct InfoPane: View {
             .accessibility(label: Text("Identical Builds"))
             .accessibility(value: Text(xcode.identicalBuilds.map(\.appleDescription).joined(separator: ", ")))
             .accessibility(hint: Text("Sometimes a prerelease and release version are the exact same build. Xcodes will automatically display these versions together."))
+        } else {
+            EmptyView()
+        }
+    }
+
+    @ViewBuilder
+    private func releaseDate(for xcode: Xcode) -> some View {
+        if let releaseDate = xcode.releaseDate {
+            VStack(alignment: .leading) {
+                Text("Release Date")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                Text(DateFormatter.downloadsReleaseDate.string(from: releaseDate))
+                    .font(.subheadline)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
         } else {
             EmptyView()
         }

--- a/Xcodes/Frontend/InfoPane/InfoPane.swift
+++ b/Xcodes/Frontend/InfoPane/InfoPane.swift
@@ -252,6 +252,7 @@ struct InfoPane_Previews: PreviewProvider {
                             icon: NSWorkspace.shared.icon(forFile: "/Applications/Xcode-12.3.0.app"),
                             requiredMacOSVersion: "10.15.4",
                             releaseNotesURL: URL(string: "https://developer.apple.com/documentation/xcode-release-notes/xcode-12_3-release-notes/")!,
+                            releaseDate: Date(),
                             sdks: SDKs(
                                 macOS: .init(number: "11.1"),
                                 iOS: .init(number: "14.3"),


### PR DESCRIPTION
Adds the release date if known to the Info Pane for each Xcode release.

- Adds optional release date property to `Xcode` struct populated from `AvailableXcode.releaseDate`
- Uses existing `DateFormatter` to display release date in the Info Pane
  - Currently placed below "Release Notes" link and above "Compatibility" section, I'm open to suggestions on better ordering

Issue: #145 

<img width="354" alt="Screenshot of Xcode (8-10-21, 9-35-05 AM)" src="https://user-images.githubusercontent.com/29579009/128898524-68cc0eaf-37ba-433e-949e-b1215f9639d6.png">
Preview screenshot to show placement and formatting of release date
