### PR TITLE
Allow Non-Paid Apple Developer to download versions.

### DIFF
--- a/Xcodes/AppleAPI/Sources/AppleAPI/Client.swift
+++ b/Xcodes/AppleAPI/Sources/AppleAPI/Client.swift
@@ -151,9 +151,12 @@ public class Client {
             .map(\.data)
             .decode(type: AppleSession.self, decoder: JSONDecoder())
             .tryMap { session in
-                if session.provider == nil {
-                    throw AuthenticationError.notDeveloperAppleId
-                }
+                // A user that is a non-paid Apple Developer will have a provider == nil
+                // Those users can still download Xcode.
+                // Non Apple Developers will get caught in the download as invalid
+//                if session.provider == nil {
+//                    throw AuthenticationError.notDeveloperAppleId
+//                }
             }
             .eraseToAnyPublisher()
     }

--- a/Xcodes/AppleAPI/Sources/AppleAPI/Client.swift
+++ b/Xcodes/AppleAPI/Sources/AppleAPI/Client.swift
@@ -200,6 +200,7 @@ public enum AuthenticationError: Swift.Error, LocalizedError, Equatable {
     case badStatusCode(statusCode: Int, data: Data, response: HTTPURLResponse)
     case notDeveloperAppleId
     case notAuthorized
+    case invalidResult(resultString: String?)
     
     public var errorDescription: String? {
         switch self {
@@ -230,6 +231,8 @@ public enum AuthenticationError: Swift.Error, LocalizedError, Equatable {
             return "You are not registered as an Apple Developer.  Please visit Apple Developer Registration. https://developer.apple.com/register/"
         case .notAuthorized:
             return "You are not authorized. Please Sign in with your Apple ID first."
+        case let .invalidResult(resultString):
+            return resultString ?? "If you continue to have problems, please submit a bug report in the Help menu."
         }
     }
 }

--- a/Xcodes/Backend/Downloads.swift
+++ b/Xcodes/Backend/Downloads.swift
@@ -3,7 +3,13 @@ import Path
 import Version
 
 struct Downloads: Codable {
-    let downloads: [Download]
+    let resultCode: Int
+    let resultsString: String?
+    let downloads: [Download]?
+    
+    var hasError: Bool {
+        return resultCode != 0
+    }
 }
 
 // Set to Int64 as ByteCountFormatter uses it.

--- a/Xcodes/Resources/Licenses.rtf
+++ b/Xcodes/Resources/Licenses.rtf
@@ -1,4 +1,4 @@
-{\rtf1\ansi\ansicpg1252\cocoartf2578
+{\rtf1\ansi\ansicpg1252\cocoartf2580
 \cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fnil\fcharset0 .SFNS-Regular;}
 {\colortbl;\red255\green255\blue255;}
 {\*\expandedcolortbl;;}
@@ -360,73 +360,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\
 SOFTWARE.\
-\
-\
-
-\fs34 Sparkle\
-\
-
-\fs26 Copyright (c) 2006-2013 Andy Matuschak.\
-Copyright (c) 2009-2013 Elgato Systems GmbH.\
-Copyright (c) 2011-2014 Kornel Lesi\uc0\u324 ski.\
-Copyright (c) 2015-2017 Mayur Pawashe.\
-Copyright (c) 2014 C.W. Betts.\
-Copyright (c) 2014 Petroules Corporation.\
-Copyright (c) 2014 Big Nerd Ranch.\
-All rights reserved.\
-\
-Permission is hereby granted, free of charge, to any person obtaining a copy of\
-this software and associated documentation files (the "Software"), to deal in\
-the Software without restriction, including without limitation the rights to\
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of\
-the Software, and to permit persons to whom the Software is furnished to do so,\
-subject to the following conditions:\
-\
-The above copyright notice and this permission notice shall be included in all\
-copies or substantial portions of the Software.\
-\
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS\
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR\
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER\
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN\
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\
-\
-=================\
-EXTERNAL LICENSES\
-=================\
-\
-bspatch.c and bsdiff.c, from bsdiff 4.3 <http://www.daemonology.net/bsdiff/>:\
-    Copyright (c) 2003-2005 Colin Percival.\
-\
-sais.c and sais.c, from sais-lite (2010/08/07) <https://sites.google.com/site/yuta256/sais>:\
-    Copyright (c) 2008-2010 Yuta Mori.\
-\
-SUDSAVerifier.m:\
-    Copyright (c) 2011 Mark Hamlin.\
-\
-All rights reserved.\
-\
-Redistribution and use in source and binary forms, with or without\
-modification, are permitted providing that the following conditions\
-are met:\
-1. Redistributions of source code must retain the above copyright\
-   notice, this list of conditions and the following disclaimer.\
-2. Redistributions in binary form must reproduce the above copyright\
-   notice, this list of conditions and the following disclaimer in the\
-   documentation and/or other materials provided with the distribution.\
-\
-THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED\
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE\
-ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY\
-DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL\
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS\
-OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)\
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,\
-STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING\
-IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE\
-POSSIBILITY OF SUCH DAMAGE.\
 \
 \
 

--- a/XcodesTests/AppStateTests.swift
+++ b/XcodesTests/AppStateTests.swift
@@ -93,7 +93,7 @@ class AppStateTests: XCTestCase {
             }
             // It's an available release version
             else if urlRequest.url! == URLRequest.downloads.url! {
-                let downloads = Downloads(downloads: [Download(name: "Xcode 0.0.0", files: [Download.File(remotePath: "https://apple.com/xcode.xip", fileSize: 9484444)], dateModified: Date())])
+                let downloads = Downloads(resultCode: 0, resultsString: nil, downloads: [Download(name: "Xcode 0.0.0", files: [Download.File(remotePath: "https://apple.com/xcode.xip", fileSize: 9484444)], dateModified: Date())])
                 let encoder = JSONEncoder()
                 encoder.dateEncodingStrategy = .formatted(.downloadsDateModified)
                 let downloadsData = try! encoder.encode(downloads)
@@ -203,7 +203,7 @@ class AppStateTests: XCTestCase {
             }
             // It's an available release version
             else if urlRequest.url! == URLRequest.downloads.url! {
-                let downloads = Downloads(downloads: [Download(name: "Xcode 0.0.0", files: [Download.File(remotePath: "https://apple.com/xcode.xip", fileSize: 9494944)], dateModified: Date())])
+                let downloads = Downloads(resultCode: 0, resultsString: nil, downloads: [Download(name: "Xcode 0.0.0", files: [Download.File(remotePath: "https://apple.com/xcode.xip", fileSize: 9494944)], dateModified: Date())])
                 let encoder = JSONEncoder()
                 encoder.dateEncodingStrategy = .formatted(.downloadsDateModified)
                 let downloadsData = try! encoder.encode(downloads)


### PR DESCRIPTION
Getting a better understanding of the different api results from different types of Apple ID's

- Non-Developer AppleID: Gives back a `Session.provider == null`, resultCode on listDownload != 0
- Non-Paid Apple Developer: Gives back `Session.provider == null`, resultCode == 0 (Allowing to download versions)
- Full paid Developer: Session.provider == "Something"

This fixes point 2 where Xcodes will now allow Non-Paid Apple developers to download Xcode versions as they should be able to. 