### PR TITLE
Use a fixed locale for API response date parsing

### DIFF
--- a/Xcodes/Backend/DateFormatter+.swift
+++ b/Xcodes/Backend/DateFormatter+.swift
@@ -5,6 +5,7 @@ extension DateFormatter {
     static let downloadsDateModified: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "MM/dd/yy HH:mm"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
         return formatter
     }()
 


### PR DESCRIPTION
Fixes: #190 

### What was the issue
As discussed in #190, there seem to be some regions and combinations of 24-hour time preference that cause return unexpected results for the date formatter used when parsing API responses.

With an region such as `en-GB` selected on a machine under System Preferences > Language and Region, and 24-hour unchecked, when using a date formatter with the string `"MM/dd/yy HH:mm"` it will actually return a string that includes the am/pm

<img width="464" alt="24hour-disabled" src="https://user-images.githubusercontent.com/1420670/162586775-dd0580ef-6818-4478-bc1d-8322e8b2378c.png">

### What's changed
Use a fixed locale of `"en_US_POSIX"` for date parsing of api responses.

### How to test

- Go to System Preferences > Language and Region on your machine
- Select Region: Europe > United Kingdom
- Uncheck `24-Hour Time`
- Launch the Xcodes app
- Try and download any Xcode version that you do not currently have installed on your machine
- Another thing to test is refreshing the list of Xcodes using the refresh button in the top menu of the app
