### PR TITLE
Adds option to create symbolic link at Path Xcode.app

### DIFF
--- a/Xcodes/AcknowledgementsGenerator/Package.swift
+++ b/Xcodes/AcknowledgementsGenerator/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.4
 
 import PackageDescription
 

--- a/Xcodes/Backend/AppState+Install.swift
+++ b/Xcodes/Backend/AppState+Install.swift
@@ -88,7 +88,7 @@ extension AppState {
     private func getXcodeArchive(_ installationType: InstallationType, downloader: Downloader) -> AnyPublisher<(AvailableXcode, URL), Error> {
         switch installationType {
         case .version(let availableXcode):
-            if let installedXcode = Current.files.installedXcodes(Path.root/"Applications").first(where: { $0.version.isEquivalent(to: availableXcode.version) }) {
+            if let installedXcode = Current.files.installedXcodes(Path.installDirectory).first(where: { $0.version.isEquivalent(to: availableXcode.version) }) {
                 return Fail(error: InstallationError.versionAlreadyInstalled(installedXcode))
                     .eraseToAnyPublisher()
             }
@@ -178,7 +178,7 @@ extension AppState {
 
     public func installArchivedXcode(_ availableXcode: AvailableXcode, at archiveURL: URL) -> AnyPublisher<InstalledXcode, Error> {
         do {
-            let destinationURL = Path.root.join("Applications").join("Xcode-\(availableXcode.version.descriptionWithoutBuildMetadata).app").url
+            let destinationURL = Path.installDirectory.join("Xcode-\(availableXcode.version.descriptionWithoutBuildMetadata).app").url
             switch archiveURL.pathExtension {
             case "xip":
                 return unarchiveAndMoveXIP(availableXcode: availableXcode, at: archiveURL, to: destinationURL)

--- a/Xcodes/Backend/Path+.swift
+++ b/Xcodes/Backend/Path+.swift
@@ -16,4 +16,8 @@ extension Path {
     static var cacheFile: Path {
         return xcodesApplicationSupport/"available-xcodes.json"
     }
+    
+    static var installDirectory: Path {
+        return Path.root/"Applications"
+    }
 }

--- a/Xcodes/Backend/XcodeCommands.swift
+++ b/Xcodes/Backend/XcodeCommands.swift
@@ -18,6 +18,7 @@ struct XcodeCommands: Commands {
                 OpenCommand()
                 RevealCommand()
                 CopyPathCommand()
+                CreateSymbolicLinkCommand()
                 
                 Divider()
                 
@@ -153,6 +154,23 @@ struct CopyPathButton: View {
     }
 }
 
+struct CreateSymbolicLinkButton: View {
+    @EnvironmentObject var appState: AppState
+    let xcode: Xcode?
+    
+    var body: some View {
+        Button(action: createSymbolicLink) {
+            Text("Create SymLink as Xcode.app")
+        }
+        .help("Create SymLink as Xcode.app")
+    }
+    
+    private func createSymbolicLink() {
+        guard let xcode = xcode else { return }
+        appState.createSymbolicLink(xcode: xcode)
+    }
+}
+
 // MARK: - Commands
 
 struct InstallCommand: View {
@@ -225,3 +243,15 @@ struct UninstallCommand: View {
             .disabled(selectedXcode.unwrapped?.installState.installed != true)
     }
 }
+
+struct CreateSymbolicLinkCommand: View {
+    @EnvironmentObject var appState: AppState
+    @FocusedValue(\.selectedXcode) private var selectedXcode: SelectedXcode?
+    
+    var body: some View {
+        CreateSymbolicLinkButton(xcode: selectedXcode.unwrapped)
+            .keyboardShortcut("s", modifiers: [.command, .option])
+            .disabled(selectedXcode.unwrapped?.installState.installed != true)
+    }
+}
+

--- a/Xcodes/Frontend/XcodeList/XcodeListViewRow.swift
+++ b/Xcodes/Frontend/XcodeList/XcodeListViewRow.swift
@@ -53,6 +53,7 @@ struct XcodeListViewRow: View {
                 OpenButton(xcode: xcode)
                 RevealButton(xcode: xcode)
                 CopyPathButton(xcode: xcode)
+                CreateSymbolicLinkButton(xcode: xcode)
                 Divider()
                 UninstallButton(xcode: xcode)
                 


### PR DESCRIPTION
As discussed in [#183](https://github.com/RobotsAndPencils/XcodesApp/issues/183) and [#183](https://github.com/RobotsAndPencils/XcodesApp/issues/110) there are sometimes dependencies that are specifically looking for `Xcodes.app` instead of using the currently selected Xcode. A workaround is by creating a symbolic link to whichever Xcode Version you'd like, but naming it `Xcode.app` 

And example from the commandline: 
```
% ln -s /Applications/Xcode-13.3.0.app /Applications/Xcode.app
```

I don't use symbolic links all that much, but hopefully this covers the basis. An enhancement on top of this could be the ability to update the symbolic link when a user selects a version (by preference only) 

![image](https://user-images.githubusercontent.com/1119565/162855543-5e14c9f8-de4b-4d0f-9c2f-cfe47b4d8c23.png)

Also refactored that anywhere we had hardcoded the `Applications` directory to look at `Path.installDirectory` instead. 


