### PR TITLE
Add Preference to make Symbolic Link Automatic on Xcode Select

### DIFF
--- a/Xcodes/Backend/AppState.swift
+++ b/Xcodes/Backend/AppState.swift
@@ -68,7 +68,13 @@ class AppState: ObservableObject {
             Current.defaults.set(unxipExperiment, forKey: "unxipExperiment")
         }
     }
-
+    
+    @Published var createSymLinkOnSelect = false {
+        didSet {
+            Current.defaults.set(createSymLinkOnSelect, forKey: "createSymLinkOnSelect")
+        }
+    }
+    
     // MARK: - Publisher Cancellables
     
     var cancellables = Set<AnyCancellable>()
@@ -489,6 +495,10 @@ class AppState: ObservableObject {
                     if case let .failure(error) = completion {
                         self.error = error
                         self.presentedAlert = .generic(title: "Unable to select Xcode", message: error.legibleLocalizedDescription)
+                    } else {
+                        if self.createSymLinkOnSelect {
+                            createSymbolicLink(xcode: xcode)
+                        }
                     }
                     self.selectPublisher = nil
                 },

--- a/Xcodes/Frontend/Preferences/AdvancedPreferencePane.swift
+++ b/Xcodes/Frontend/Preferences/AdvancedPreferencePane.swift
@@ -43,7 +43,20 @@ struct AdvancedPreferencePane: View {
                         .font(.footnote)
                         .fixedSize(horizontal: false, vertical: true)
                 }
-                
+            }
+            .groupBoxStyle(PreferencesGroupBoxStyle())
+            
+            GroupBox(label: Text("Active/Select")) {
+                VStack(alignment: .leading) {
+                    Toggle(
+                        "Automatically create symbolic link to Xcodes.app",
+                        isOn: $appState.createSymLinkOnSelect
+                    )
+                    Text("When making an Xcode version Active/Selected, try and create a symbolic link named Xcode.app in the installation directory")
+                        .font(.footnote)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .fixedSize(horizontal: false, vertical: true)
             }
             .groupBoxStyle(PreferencesGroupBoxStyle())
             


### PR DESCRIPTION
Adds an option to Advance Preferences to automatically update the Symbolic Link for Xcodes.app to whatever Xcode version you've selected. 

<img width="525" alt="image" src="https://user-images.githubusercontent.com/1119565/163303224-94bcbefa-4fc8-4057-acc1-679662fa10e4.png">

Closes #180 