### PR TITLE
Fix: Load create SymLink preference on start

### DIFF
--- a/Xcodes/Backend/AppState.swift
+++ b/Xcodes/Backend/AppState.swift
@@ -109,6 +109,7 @@ class AppState: ObservableObject {
     func setupDefaults() {
         localPath = Current.defaults.string(forKey: "localPath") ?? Path.defaultXcodesApplicationSupport.string
         unxipExperiment = Current.defaults.bool(forKey: "unxipExperiment") ?? false
+        createSymLinkOnSelect = Current.defaults.bool(forKey: "createSymLinkOnSelect") ?? false
     }
     
     // MARK: Timer


### PR DESCRIPTION
Fixes #202 

App did not load the create symlink preference on start, and therefore showed the incorrect option on the preferences.

