### PR TITLE
Fixes some localization formatting from string to ints

### DIFF
--- a/Xcodes/Resources/en.lproj/Localizable.strings
+++ b/Xcodes/Resources/en.lproj/Localizable.strings
@@ -39,8 +39,8 @@
 "NoXcodeSelected" = "No Xcode Selected";
 
 // Installation Steps
-"InstallationStepDescription" = "Step %@ of %@: %@";
-"DownloadingPercentDescription" = "Downloading: %@% complete";
+"InstallationStepDescription" = "Step %d of %d: %@";
+"DownloadingPercentDescription" = "Downloading: %d%% complete";
 "StopInstallation" = "Stop installation";
 "DownloadingError" = "No download information found";
 
@@ -106,10 +106,10 @@
 "SignOut" = "Sign Out";
 
 // SMS/2FA
-"DigitCodeDescription" = "Enter the %@ digit code from one of your trusted devices:";
+"DigitCodeDescription" = "Enter the %d digit code from one of your trusted devices:";
 "SendSMS" = "Send SMS";
-"EnterDigitCodeDescription" = "Enter the %@ digit code sent to %@: ";
-"SelectTrustedPhone" = "Select a trusted phone number to receive a %@ digit code via SMS:";
+"EnterDigitCodeDescription" = "Enter the %d digit code sent to %@: ";
+"SelectTrustedPhone" = "Select a trusted phone number to receive a %d digit code via SMS:";
 "NoTrustedPhones" = "Your account doesn't have any trusted phone numbers, but they're required for two-factor authentication.\n\nSee https://support.apple.com/en-ca/HT204915.";
 
 // MainWindow


### PR DESCRIPTION
From the localization updates in #203 there were some format's using `%@` instead of `%d` for when we need an int. 

