### PR TITLE
Update Sparkle to 2.1

### DIFF
--- a/Xcodes.xcodeproj/project.pbxproj
+++ b/Xcodes.xcodeproj/project.pbxproj
@@ -1412,8 +1412,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/sparkle-project/Sparkle/";
 			requirement = {
-				kind = exactVersion;
-				version = "1.24.0-spm";
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Xcodes.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Xcodes.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/sparkle-project/Sparkle/",
         "state": {
           "branch": null,
-          "revision": "891afd44c7075e699924ed9b81d8dc94a5111dfd",
-          "version": "1.24.0-spm"
+          "revision": "286edd1fa22505a9e54d170e9fd07d775ea233f2",
+          "version": "2.1.0"
         }
       },
       {

--- a/Xcodes/Frontend/Preferences/PreferencesView.swift
+++ b/Xcodes/Frontend/Preferences/PreferencesView.swift
@@ -5,6 +5,7 @@ struct PreferencesView: View {
         case general, updates, advanced, experiment
     }
     @EnvironmentObject var appState: AppState
+    @EnvironmentObject var updater: ObservableUpdater
     
     var body: some View {
         TabView {
@@ -15,6 +16,7 @@ struct PreferencesView: View {
                 }
                 .tag(Tabs.general)
             UpdatesPreferencePane()
+                .environmentObject(updater)
                 .tabItem {
                     Label("Updates", systemImage: "arrow.triangle.2.circlepath.circle")
                 }

--- a/Xcodes/Resources/Licenses.rtf
+++ b/Xcodes/Resources/Licenses.rtf
@@ -402,7 +402,7 @@ bspatch.c and bsdiff.c, from bsdiff 4.3 <http://www.daemonology.net/bsdiff/>:\
 sais.c and sais.c, from sais-lite (2010/08/07) <https://sites.google.com/site/yuta256/sais>:\
     Copyright (c) 2008-2010 Yuta Mori.\
 \
-SUDSAVerifier.m:\
+SUSignatureVerifier.m:\
     Copyright (c) 2011 Mark Hamlin.\
 \
 All rights reserved.\

--- a/Xcodes/XcodesApp.swift
+++ b/Xcodes/XcodesApp.swift
@@ -8,11 +8,13 @@ struct XcodesApp: App {
     @SwiftUI.Environment(\.scenePhase) private var scenePhase: ScenePhase
     @SwiftUI.Environment(\.openURL) var openURL: OpenURLAction
     @StateObject private var appState = AppState()
-    
+    @StateObject private var updater = ObservableUpdater()
+   
     var body: some Scene {
         WindowGroup("Xcodes") {
             MainWindow()
                 .environmentObject(appState)
+                .environmentObject(updater)
                 // This is intentionally used on a View, and not on a WindowGroup, 
                 // so that it's triggered when an individual window's phase changes instead of all window phases.
                 // When used on a View it's also invoked on launch, which doesn't occur with a WindowGroup. 
@@ -32,7 +34,7 @@ struct XcodesApp: App {
             }
             CommandGroup(after: .appInfo) {
                 Button("Menu.CheckForUpdates") {
-                    appDelegate.checkForUpdates()
+                    updater.checkForUpdates()
                 }
             }
         
@@ -69,6 +71,7 @@ struct XcodesApp: App {
         Settings {
             PreferencesView()
                 .environmentObject(appState)
+                .environmentObject(updater)
         }
         #endif
     }
@@ -112,13 +115,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         acknowledgementsWindow.makeKeyAndOrderFront(nil)
     }
     
-    func checkForUpdates() {
-        SUUpdater.shared()?.checkForUpdates(self)
-    }
-    
     func applicationDidFinishLaunching(_ notification: Notification) {
-        // Initialize manually
-        SUUpdater.shared()
+      
     }
 }
 


### PR DESCRIPTION
Updates Sparkle to 2.1. 

Major update, so had some refactoring as long as was the Sparkle singleton flow. 

Passes up a new environment Object to use in the Update Preferences pane so it shares the one Updater.  

To Test:
- Run app and try and check for updates. 
- Change version to a lower version + build, check for updates. Sparkle should prompt for new version. 