### PR TITLE
Update Release Date format on InfoPane for better localization

### DIFF
--- a/Xcodes/Frontend/InfoPane/InfoPane.swift
+++ b/Xcodes/Frontend/InfoPane/InfoPane.swift
@@ -120,7 +120,7 @@ struct InfoPane: View {
                 Text("ReleaseDate")
                     .font(.headline)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                Text(DateFormatter.downloadsReleaseDate.string(from: releaseDate))
+                Text("\(releaseDate, style: .date)")
                     .font(.subheadline)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }


### PR DESCRIPTION
Thanks to localized by community, we found some incorrect date format localization. https://github.com/RobotsAndPencils/XcodesApp/pull/249#issuecomment-1152891477

Before:
<img width="960" alt="Screen Shot 2022-06-12 at 7 18 38" src="https://user-images.githubusercontent.com/20222809/173206653-93656498-2110-442b-9ebe-d074996f454a.png">

After:
<img width="961" alt="Screen Shot 2022-06-12 at 7 20 14" src="https://user-images.githubusercontent.com/20222809/173206692-919a36bb-7778-47c7-924e-cda1e23ee62f.png">

