### PR TITLE
Fix minimum version supported localization alert message

### DIFF
--- a/Xcodes/Frontend/MainWindow.swift
+++ b/Xcodes/Frontend/MainWindow.swift
@@ -156,7 +156,7 @@ struct MainWindow: View {
         case let .checkMinSupportedVersion(xcode, deviceVersion):
             return Alert(
                 title: Text("Alert.MinSupported.Title"),
-                message: Text(String(format: "Alert.MinSupported.Message", xcode.version.descriptionWithoutBuildMetadata, xcode.requiredMacOSVersion ?? "", deviceVersion)),
+                message: Text(String(format: localizeString("Alert.MinSupported.Message"), xcode.version.descriptionWithoutBuildMetadata, xcode.requiredMacOSVersion ?? "", deviceVersion)),
                   primaryButton: .default(
                     Text("Install"),
                     action: {


### PR DESCRIPTION
Fixes #244 

The localization for the minimum supported version alert wasn't showing properly

Before:
<img width="299" alt="image" src="https://user-images.githubusercontent.com/1119565/173469481-103b68e8-c0b7-4c13-86c9-0a42f435e430.png">
After (faking it out):
<img width="271" alt="image" src="https://user-images.githubusercontent.com/1119565/173469359-2bf92370-69bf-4d17-99b4-95c607701e64.png">
