### PR TITLE
Adds Copy Release Notes URL context menu

### DIFF
--- a/Xcodes/Backend/AppState.swift
+++ b/Xcodes/Backend/AppState.swift
@@ -535,6 +535,13 @@ class AppState: ObservableObject {
         NSPasteboard.general.writeObjects([installedXcodePath.url as NSURL])
         NSPasteboard.general.setString(installedXcodePath.string, forType: .string)
     }
+
+    func copyReleaseNote(xcode: Xcode) {
+      guard let url = xcode.releaseNotesURL else { return }
+      NSPasteboard.general.declareTypes([.URL, .string], owner: nil)
+      NSPasteboard.general.writeObjects([url as NSURL])
+      NSPasteboard.general.setString(url.absoluteString, forType: .string)
+    }
     
     func createSymbolicLink(xcode: Xcode) {
         guard let installedXcodePath = xcode.installedPath else { return }

--- a/Xcodes/Backend/XcodeCommands.swift
+++ b/Xcodes/Backend/XcodeCommands.swift
@@ -154,6 +154,24 @@ struct CopyPathButton: View {
     }
 }
 
+struct CopyReleaseNoteButton: View {
+  @EnvironmentObject var appState: AppState
+  let xcode: Xcode?
+
+  var body: some View {
+    Button(action: copyReleaseNote) {
+      Text("CopyReleaseNoteURL")
+    }
+    .help("CopyReleaseNoteURL")
+  }
+
+  private func copyReleaseNote() {
+    guard let xcode = xcode else { return }
+    appState.copyReleaseNote(xcode: xcode)
+  }
+}
+
+
 struct CreateSymbolicLinkButton: View {
     @EnvironmentObject var appState: AppState
     let xcode: Xcode?

--- a/Xcodes/Frontend/InfoPane/InfoPane.swift
+++ b/Xcodes/Frontend/InfoPane/InfoPane.swift
@@ -136,11 +136,19 @@ struct InfoPane: View {
                 Label("ReleaseNotes", systemImage: "link")
             }
             .buttonStyle(LinkButtonStyle())
+            .contextMenu(menuItems: {
+              releaseNotesMenu(for: xcode)
+            })
             .frame(maxWidth: .infinity, alignment: .leading)
             .help("ReleaseNotes.help")
         } else {
             EmptyView()
         }
+    }
+
+    @ViewBuilder
+    private func releaseNotesMenu(for xcode: Xcode) -> some View {
+        CopyReleaseNoteButton(xcode: xcode)
     }
     
     @ViewBuilder

--- a/Xcodes/Resources/de.lproj/Localizable.strings
+++ b/Xcodes/Resources/de.lproj/Localizable.strings
@@ -32,6 +32,7 @@
 "ReleaseDate" = "Release-Datum";
 "ReleaseNotes" = "Release-Notes";
 "ReleaseNotes.help" = "Release-Notes anzeigen";
+"CopyReleaseNoteURL" = "URL kopieren";
 "Compatibility" = "Kompatibilität";
 "MacOSRequirement" = "Erfordert macOS %@ oder neuer";
 "SDKs" = "SDKs";

--- a/Xcodes/Resources/en.lproj/Localizable.strings
+++ b/Xcodes/Resources/en.lproj/Localizable.strings
@@ -32,6 +32,7 @@
 "ReleaseDate" = "Release Date";
 "ReleaseNotes" = "Release Notes";
 "ReleaseNotes.help" = "View Release Notes";
+"CopyReleaseNoteURL" = "Copy URL";
 "Compatibility" = "Compatibility";
 "MacOSRequirement" = "Requires macOS %@ or later";
 "SDKs" = "SDKs";

--- a/Xcodes/Resources/es.lproj/Localizable.strings
+++ b/Xcodes/Resources/es.lproj/Localizable.strings
@@ -32,6 +32,7 @@
 "ReleaseDate" = "Fecha de lanzamiento";
 "ReleaseNotes" = "Notas del lanzamiento";
 "ReleaseNotes.help" = "Ver Notas del Lanzamiento";
+"CopyReleaseNoteURL" = "Copiar URL";
 "Compatibility" = "Compatibilidad";
 "MacOSRequirement" = "Requiere macOS %@ o posterior";
 "SDKs" = "SDKs";

--- a/Xcodes/Resources/fr.lproj/Localizable.strings
+++ b/Xcodes/Resources/fr.lproj/Localizable.strings
@@ -10,6 +10,7 @@
 "Install" = "Installer";
 "InstallDescription" = "Installer cette version";
 "RevealInFinder" = "Ouvrir dans le Finder";
+"CopyReleaseNoteURL" = "Copier l'URL";
 "Active" = "Version Active";
 "MakeActive" = "Activer";
 "Open" = "Ouvrir";

--- a/Xcodes/Resources/hi.lproj/Localizable.strings
+++ b/Xcodes/Resources/hi.lproj/Localizable.strings
@@ -31,6 +31,7 @@
 "ReleaseDate" = "रिलीज़ दिनांक";
 "ReleaseNotes" = "रिलीज नोट्स";
 "ReleaseNotes.help" = "रिलीज़ नोट्स देखें";
+"CopyReleaseNoteURL" = "URL कॉपी करें";
 "Compatibility" = "अनुकूलता";
 "MacOSRequirement" = "macOS %@ या बाद के संस्करण की आवश्यकता है";
 "SDKs" = "SDKs";

--- a/Xcodes/Resources/it.lproj/Localizable.strings
+++ b/Xcodes/Resources/it.lproj/Localizable.strings
@@ -32,6 +32,7 @@
 "ReleaseDate" = "Data di Rilascio";
 "ReleaseNotes" = "Note di Rilascio";
 "ReleaseNotes.help" = "Vedi Note di Rilascio";
+"CopyReleaseNoteURL" = "Copia URL";
 "Compatibility" = "Compatibilità";
 "MacOSRequirement" = "Richiede macOS %@ o successivo";
 "SDKs" = "SDKs";

--- a/Xcodes/Resources/ja.lproj/Localizable.strings
+++ b/Xcodes/Resources/ja.lproj/Localizable.strings
@@ -32,6 +32,7 @@
 "ReleaseDate" = "リリース日";
 "ReleaseNotes" = "リリースノート";
 "ReleaseNotes.help" = "リリースノートを表示";
+"CopyReleaseNoteURL" = "URLをコピー";
 "Compatibility" = "互換性";
 "MacOSRequirement" = "macOS %@ 以降";
 "SDKs" = "SDK";

--- a/Xcodes/Resources/ko.lproj/Localizable.strings
+++ b/Xcodes/Resources/ko.lproj/Localizable.strings
@@ -32,6 +32,7 @@
 "ReleaseDate" = "출시일";
 "ReleaseNotes" = "릴리즈 노트";
 "ReleaseNotes.help" = "릴리즈 노트 보기";
+"CopyReleaseNoteURL" = "URL 복사";
 "Compatibility" = "호환성";
 "MacOSRequirement" = "macOS %@ 또는 이후 버전";
 "SDKs" = "SDKs";

--- a/Xcodes/Resources/ru.lproj/Localizable.strings
+++ b/Xcodes/Resources/ru.lproj/Localizable.strings
@@ -31,6 +31,7 @@
 "ReleaseDate" = "Дата выпуска";
 "ReleaseNotes" = "Примечания к выпуску";
 "ReleaseNotes.help" = "Просмотреть примечания к выпуску";
+"CopyReleaseNoteURL" = "Копировать URL";
 "Compatibility" = "Совместимость";
 "MacOSRequirement" = "Требуется macOS %@ или новее";
 "SDKs" = "SDK";

--- a/Xcodes/Resources/tr.lproj/Localizable.strings
+++ b/Xcodes/Resources/tr.lproj/Localizable.strings
@@ -32,6 +32,7 @@
 "ReleaseDate" = "Yayınlanma Tarihi";
 "ReleaseNotes" = "Yayınlanma Notları";
 "ReleaseNotes.help" = "Yayınlanma Notlarını Görüntüle";
+"CopyReleaseNoteURL" = "URL'yi kopyala";
 "Compatibility" = "Uyumluluk";
 "MacOSRequirement" = "macOS %@ veya sonrasını gerektirir";
 "SDKs" = "SDKler";

--- a/Xcodes/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Xcodes/Resources/zh-Hans.lproj/Localizable.strings
@@ -32,6 +32,7 @@
 "ReleaseDate" = "发布日期";
 "ReleaseNotes" = "更新说明";
 "ReleaseNotes.help" = "查看更新说明";
+"CopyReleaseNoteURL" = "复制 URL";
 "Compatibility" = "兼容性";
 "MacOSRequirement" = "需要macOS %@及以上";
 "SDKs" = "SDK";

--- a/Xcodes/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Xcodes/Resources/zh-Hant.lproj/Localizable.strings
@@ -32,6 +32,7 @@
 "ReleaseDate" = "發行日期";
 "ReleaseNotes" = "版本附註";
 "ReleaseNotes.help" = "檢視版本附註";
+"CopyReleaseNoteURL" = "複製 URL";
 "Compatibility" = "相容性";
 "MacOSRequirement" = "需要 macOS %@ 或以上版本";
 "SDKs" = "SDKs";


### PR DESCRIPTION
Added the ability to copy the URL of release notes by right-clicking on it.

<img width="303" alt="Screen Shot 2022-06-17 at 13 56 32" src="https://user-images.githubusercontent.com/20222809/174228006-164d748a-0761-4dab-ad9f-1e92003f63d7.png">
