### PR TITLE
Fix macOS Ventura crash on Settings View 

### DIFF
--- a/Xcodes/Frontend/Preferences/AdvancedPreferencePane.swift
+++ b/Xcodes/Frontend/Preferences/AdvancedPreferencePane.swift
@@ -118,7 +118,6 @@ struct AdvancedPreferencePane: View {
             }
             .groupBoxStyle(PreferencesGroupBoxStyle())
         }
-        .frame(width: 500)
     }
     
     private var dataSourceFootnote: NSAttributedString {
@@ -153,6 +152,7 @@ struct AdvancedPreferencePane_Previews: PreviewProvider {
         Group {
             AdvancedPreferencePane()
                 .environmentObject(AppState())
+                .frame(maxWidth: 500)
         }
     }
 }

--- a/Xcodes/Frontend/Preferences/ExperiementsPreferencePane.swift
+++ b/Xcodes/Frontend/Preferences/ExperiementsPreferencePane.swift
@@ -21,7 +21,6 @@ struct ExperimentsPreferencePane: View {
             
             Divider()
         }
-        .frame(width: 500)
     }
     
     private var unxipFootnote: NSAttributedString {
@@ -44,6 +43,7 @@ struct ExperimentsPreferencePane_Previews: PreviewProvider {
         Group {
             ExperimentsPreferencePane()
                 .environmentObject(AppState())
+                .frame(maxWidth: 500)
         }
     }
 }

--- a/Xcodes/Frontend/Preferences/GeneralPreferencePane.swift
+++ b/Xcodes/Frontend/Preferences/GeneralPreferencePane.swift
@@ -21,7 +21,6 @@ struct GeneralPreferencePane: View {
             }
             .groupBoxStyle(PreferencesGroupBoxStyle())
         }
-        .frame(width: 500)
     }
 }
 
@@ -30,6 +29,7 @@ struct GeneralPreferencePane_Previews: PreviewProvider {
         Group {
             GeneralPreferencePane()
                 .environmentObject(AppState())
+                .frame(maxWidth: 500)
         }
     }
 }

--- a/Xcodes/Frontend/Preferences/PreferencesView.swift
+++ b/Xcodes/Frontend/Preferences/PreferencesView.swift
@@ -34,5 +34,6 @@ struct PreferencesView: View {
                 .tag(Tabs.experiment)
         }
         .padding(20)
+        .frame(width: 500)
     }
 }

--- a/Xcodes/Frontend/Preferences/UpdatesPreferencePane.swift
+++ b/Xcodes/Frontend/Preferences/UpdatesPreferencePane.swift
@@ -51,7 +51,6 @@ struct UpdatesPreferencePane: View {
             }
             .groupBoxStyle(PreferencesGroupBoxStyle())
         }
-        .frame(width: 500)
     }
     
     private var lastUpdatedString: String {
@@ -127,6 +126,7 @@ struct UpdatesPreferencePane_Previews: PreviewProvider {
         Group {
             UpdatesPreferencePane()
                 .environmentObject(AppState())
+                .frame(maxWidth: 500)
         }
     }
 }


### PR DESCRIPTION
Fixes #242.

This PR fixes a SwiftUI related crash on macOS Ventura (both beta1 and 2) when users enter the `Advanced` settings tab and then navigate to another tab.

This crash can be solved by moving pane `.frame(width:)` to its parents. I know it's tricky, but it should solve this issue.

## Test Checklist
- [x] macOS Ventura Beta2 (22A5286j)
- [x] macOS Monterey 12.4 (21F79)
- [x] macOS Big Sur 11.6.7 (20G630)
