### PR TITLE
Use monospaced digit font for download progress

### DIFF
--- a/Xcodes/Frontend/Common/ObservingProgressIndicator.swift
+++ b/Xcodes/Frontend/Common/ObservingProgressIndicator.swift
@@ -50,7 +50,7 @@ public struct ObservingProgressIndicator: View {
             
             if showsAdditionalDescription, progress.progress.xcodesLocalizedDescription.isEmpty == false {
                 Text(progress.progress.xcodesLocalizedDescription)
-                    .font(.subheadline)
+                    .font(.subheadline.monospacedDigit())
                     .foregroundColor(.secondary)
             }
         }


### PR DESCRIPTION
Hi,

This is a really minor change to use monospaced digits for the download progress (X.X GB of Y.Y GB), which prevents the label from jumping around so much when the numbers change.

Thanks!