### PR TITLE
Add ability to download Xcode without logging in using XcodeReleases

### DIFF
--- a/Xcodes/Backend/AvailableXcode.swift
+++ b/Xcodes/Backend/AvailableXcode.swift
@@ -14,6 +14,9 @@ public struct AvailableXcode: Codable {
     public let sdks: SDKs?
     public let compilers: Compilers?
     public let fileSize: Int64?
+    public var downloadPath: String {
+        return url.path
+    }
 
     public init(
         version: Version,

--- a/Xcodes/Backend/Environment.swift
+++ b/Xcodes/Backend/Environment.swift
@@ -43,7 +43,7 @@ public struct Shell {
             "--max-connection-per-server=16",
             "--split=16",
             "--summary-interval=1",
-            "--stop-with-process=\(ProcessInfo.processInfo.processIdentifier)",
+            "--stop-with-process=\(ProcessInfo.processInfo.processIdentifier)", // if xcodes quits, stop aria2 process
             "--dir=\(destination.parent.string)",
             "--out=\(destination.basename())",
             "--human-readable=false", // sets the output to use bytes instead of formatting

--- a/Xcodes/Backend/URLRequest+Apple.swift
+++ b/Xcodes/Backend/URLRequest+Apple.swift
@@ -4,6 +4,7 @@ extension URL {
     static let download = URL(string: "https://developer.apple.com/download")!
     static let downloads = URL(string: "https://developer.apple.com/services-account/QH65B2/downloadws/listDownloads.action")!
     static let downloadXcode = URL(string: "https://developer.apple.com/devcenter/download.action")!
+    static let downloadADCAuth = URL(string: "https://developerservices2.apple.com/services/download")!
 }
 
 extension URLRequest {
@@ -19,6 +20,15 @@ extension URLRequest {
 
     static func downloadXcode(path: String) -> URLRequest {
         var components = URLComponents(url: .downloadXcode, resolvingAgainstBaseURL: false)!
+        components.queryItems = [URLQueryItem(name: "path", value: path)]
+        var request = URLRequest(url: components.url!)
+        request.allHTTPHeaderFields = request.allHTTPHeaderFields ?? [:]
+        request.allHTTPHeaderFields?["Accept"] = "*/*"
+        return request
+    }
+    
+    static func downloadADCAuth(path: String) -> URLRequest {
+        var components = URLComponents(url: .downloadADCAuth, resolvingAgainstBaseURL: false)!
         components.queryItems = [URLQueryItem(name: "path", value: path)]
         var request = URLRequest(url: components.url!)
         request.allHTTPHeaderFields = request.allHTTPHeaderFields ?? [:]


### PR DESCRIPTION
I hate having to log into my Apple Developer account, always having to put in my 2fa code, when I want to download Xcode, but Apple has never given us the ability to do so.

This PR changes that.

By using a public URL provided by Apple, we can get a token cookie that can be used to download the version of Xcode that we wish, without having to provide a log in. 🎉 

Caveats:
- This does not work when using the `Apple` datasource. More specifically that token doesn't work for listing the Xcode versions with `https://developer.apple.com/services-account/QH65B2/downloadws/listDownloads.action` 

