### PR TITLE
fix: Preference button on toolbar not working on Mac OS 13 Ventura

### DIFF
--- a/Xcodes/Frontend/XcodeList/MainToolbar.swift
+++ b/Xcodes/Frontend/XcodeList/MainToolbar.swift
@@ -86,7 +86,13 @@ struct MainToolbarModifier: ViewModifier {
             .keyboardShortcut(KeyboardShortcut("i", modifiers: [.command, .option]))
             .help("InfoDescription")
 
-            Button(action: { NSApp.sendAction(Selector(("showPreferencesWindow:")), to: nil, from: nil) }, label: {
+            Button(action: {
+                if #available(macOS 13, *) {
+                    NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+                } else {
+                    NSApp.sendAction(Selector(("showPreferencesWindow:")), to: nil, from: nil)
+                }   
+            }, label: {
                 Label("Preferences", systemImage: "gearshape")
             })
             .help("PreferencesDescription")


### PR DESCRIPTION
Apple have renamed `showPreferencesWindow` to `showSettingsWindow` which was stopping the cog icon from doing anything on Mac OS 13