### PR TITLE
Fix the ProgressView crash with List.

### DIFF
--- a/Xcodes/Frontend/Common/ObservingProgressIndicator.swift
+++ b/Xcodes/Frontend/Common/ObservingProgressIndicator.swift
@@ -46,6 +46,7 @@ public struct ObservingProgressIndicator: View {
                 isIndeterminate: progress.progress.isIndeterminate,
                 style: style
             )
+            .accessibilityElement(children: .ignore)
             .help(String(format: localizeString("DownloadingPercentDescription"), Int((progress.progress.fractionCompleted * 100))))
             
             if showsAdditionalDescription, progress.progress.xcodesLocalizedDescription.isEmpty == false {

--- a/Xcodes/Frontend/InfoPane/InstallationStepDetailView.swift
+++ b/Xcodes/Frontend/InfoPane/InstallationStepDetailView.swift
@@ -18,6 +18,7 @@ struct InstallationStepDetailView: View {
 
                 case .unarchiving, .moving, .trashingArchive, .checkingSecurity, .finishing:
                     ProgressView()
+                        .accessibilityElement(children: .ignore)
                         .scaleEffect(0.5)
             }
         }


### PR DESCRIPTION
Fix issue #230 

On macOS, when a list item containing a ProgressView is selected, the accessibility of the ProgressView is treated as if it exists by default. Even if we never set the accessibility property.

I only fix `ProgressView` in `XcodeListView`. 
Maybe the other `ProgressView` need to be fixed as well and you should check them.


If you want to reproduce, here is a minimum reproducible example.
https://github.com/uyloal/progressview-crash-when-list-scroll
