### PR TITLE
Switch Xcode releases back to using Apple Auth :(

### DIFF
--- a/Xcodes/Backend/AppState+Install.swift
+++ b/Xcodes/Backend/AppState+Install.swift
@@ -43,7 +43,10 @@ extension AppState {
         
         Logger.appState.info("Using \(downloader) downloader")
         
-        return self.getXcodeArchive(installationType, downloader: downloader)
+        return validateSession()
+            .flatMap { _ in
+                self.getXcodeArchive(installationType, downloader: downloader)
+            }
             .flatMap { xcode, url -> AnyPublisher<InstalledXcode, Swift.Error> in
                 self.installArchivedXcode(xcode, at: url)
             }
@@ -93,15 +96,12 @@ extension AppState {
     }
 
     private func downloadXcode(availableXcode: AvailableXcode, downloader: Downloader) -> AnyPublisher<(AvailableXcode, URL), Error> {
-        return validateADCSession(path: availableXcode.downloadPath)
-            .flatMap { _ in
-                return self.downloadOrUseExistingArchive(for: availableXcode, downloader: downloader, progressChanged: { [unowned self] progress in
-                    DispatchQueue.main.async {
-                        self.setInstallationStep(of: availableXcode.version, to: .downloading(progress: progress))
-                    }
-                })
-                .map { return (availableXcode, $0) }
-            }
+            self.downloadOrUseExistingArchive(for: availableXcode, downloader: downloader, progressChanged: { [unowned self] progress in
+                DispatchQueue.main.async {
+                    self.setInstallationStep(of: availableXcode.version, to: .downloading(progress: progress))
+                }
+            })
+            .map { return (availableXcode, $0) }
             .eraseToAnyPublisher()
     }
     

--- a/Xcodes/Backend/AppState.swift
+++ b/Xcodes/Backend/AppState.swift
@@ -381,7 +381,7 @@ class AppState: ObservableObject {
         case .apple:
             install(id: id)
         case .xcodeReleases:
-            installWithoutLogin(id: id)
+            install(id: id)
         }
     }
     
@@ -454,6 +454,7 @@ class AppState: ObservableObject {
     }
     
     /// Skips using the username/password to log in to Apple, and simply gets a Auth Cookie used in downloading
+    /// As of Nov 2022 this was returning a 403 forbidden
     func installWithoutLogin(id: Xcode.ID) {
         guard let availableXcode = availableXcodes.first(where: { $0.version == id }) else { return }
         


### PR DESCRIPTION
In Sept 2022, Xcodes was updated to use the same mechanism that is used to download runtimes with no login, to download Xcode.

ie: https://developerservices2.apple.com/services/download?path=/Developer_Tools/tvOS_16.1_Simulator_Runtime/tvOS_16.1_Simulator_Runtime.dmg returns 200 to set the ADCDownloadAuth cookie to be able to download

As of mid Nov 2022, Apple has return 403 (forbidden) for this endpoint for Xcode versions only. Runtimes still return 200.

https://developerservices2.apple.com/services/download?path=/Developer_Tools/Xcode_14.0.1/Xcode_14.0.1.xip

I'm not sure if this is deliberate from Apple (My guess is it is), but this PR reinstates the old way of download xcodes as all libraries and utilities have done for years now.

I don't think Apple will ever allow this open again. I do hope at some point, there is a way that I can use app specific passwords, or some other means, where I don't have to ask for a dev's Apple username/password.


#SadMatt