### PR TITLE
Improve UX when the user is not logged in

### DIFF
--- a/Xcodes/AppleAPI/Sources/AppleAPI/Client.swift
+++ b/Xcodes/AppleAPI/Sources/AppleAPI/Client.swift
@@ -182,6 +182,7 @@ public class Client {
 // MARK: - Types
 
 public enum AuthenticationState: Equatable {
+    case checking
     case unauthenticated
     case waitingForSecondFactor(TwoFactorOption, AuthOptionsResponse, AppleSessionData)
     case authenticated

--- a/Xcodes/Backend/AppState.swift
+++ b/Xcodes/Backend/AppState.swift
@@ -13,7 +13,8 @@ class AppState: ObservableObject {
    
     // MARK: - Published Properties
     
-    @Published var authenticationState: AuthenticationState = .unauthenticated
+    @Published var authenticationState: AuthenticationState = .checking
+    var isCheckingAuthentication: Bool { authenticationState == .checking }
     @Published var availableXcodes: [AvailableXcode] = [] {
         willSet {
             if newValue.count > availableXcodes.count && availableXcodes.count != 0 {
@@ -134,6 +135,21 @@ class AppState: ObservableObject {
         checkIfHelperIsInstalled()
         setupAutoInstallTimer()
         setupDefaults()
+        
+        validateSession()
+            .receive(on: DispatchQueue.main)
+            .sink(
+                receiveCompletion: { [weak self] result in
+                    switch result {
+                    case .finished:
+                        self?.authenticationState = .authenticated
+                    case .failure:
+                        self?.authenticationState = .unauthenticated
+                    }
+                },
+                receiveValue: { _ in }
+            )
+            .store(in: &cancellables)
     }
     
     func setupDefaults() {
@@ -286,7 +302,7 @@ class AppState: ObservableObject {
             self.authError = error
         case .finished:
             switch self.authenticationState {
-                case .authenticated, .unauthenticated, .notAppleDeveloper:
+                case .authenticated, .unauthenticated, .notAppleDeveloper, .checking:
                 self.presentedSheet = nil
             case let .waitingForSecondFactor(option, authOptions, sessionData):
                 self.handleTwoFactorOption(option, authOptions: authOptions, serviceKey: sessionData.serviceKey, sessionID: sessionData.sessionID, scnt: sessionData.scnt)
@@ -396,7 +412,7 @@ class AppState: ObservableObject {
                 self.$authenticationState
                     .filter { state in
                         switch state {
-                            case .authenticated, .unauthenticated, .notAppleDeveloper: return true
+                            case .authenticated, .unauthenticated, .notAppleDeveloper, .checking: return true
                         case .waitingForSecondFactor: return false
                         }
                     }

--- a/Xcodes/Frontend/XcodeList/MainToolbar.swift
+++ b/Xcodes/Frontend/XcodeList/MainToolbar.swift
@@ -14,14 +14,20 @@ struct MainToolbarModifier: ViewModifier {
 
     private var toolbar: some ToolbarContent {
         ToolbarItemGroup(placement: .status) {
-            Button(action: { appState.presentedSheet = .signIn }, label: {
-                if appState.authenticationState == .authenticated {
+            ProgressButton(
+                isInProgress: appState.isCheckingAuthentication,
+                action: { appState.presentedSheet = .signIn }
+            ) {
+                switch appState.authenticationState {
+                case .authenticated:
                     Label("Login", systemImage: "person.circle")
-                } else {
+                case .unauthenticated, .notAppleDeveloper, .checking, .waitingForSecondFactor:
                     Label("Login", systemImage: "person.circle")
                         .foregroundColor(Color.red)
+                    Text("Signed out") // TODO: Localization
+                        .foregroundColor(Color.red)
                 }
-            })
+            }
             .help("LoginDescription")
 
             ProgressButton(

--- a/Xcodes/Frontend/XcodeList/MainToolbar.swift
+++ b/Xcodes/Frontend/XcodeList/MainToolbar.swift
@@ -15,7 +15,12 @@ struct MainToolbarModifier: ViewModifier {
     private var toolbar: some ToolbarContent {
         ToolbarItemGroup(placement: .status) {
             Button(action: { appState.presentedSheet = .signIn }, label: {
-                Label("Login", systemImage: "person.circle")
+                if appState.authenticationState == .authenticated {
+                    Label("Login", systemImage: "person.circle")
+                } else {
+                    Label("Login", systemImage: "person.circle")
+                        .foregroundColor(Color.red)
+                }
             })
             .help("LoginDescription")
 


### PR DESCRIPTION
When running XcodesApp for the first time, it took me a while to figure out that I need to log in before I can download Xcode - it was a while ago, but the error was quite unclear at the time (see https://github.com/RobotsAndPencils/XcodesApp/issues/164 and https://github.com/RobotsAndPencils/XcodesApp/pull/165). This has been fixed since, but I hope making the button red when the user is not authenticated will improve the UX a little bit, guiding the user to click it.

It's a minor improvement that was at the back of my mind ever since that first time and I finally got around to implementing it. Please let me know if this kind of UI change is welcome or not.

<img width="1012" alt="Xcodes_red_auth_button" src="https://user-images.githubusercontent.com/4419793/205448073-320699c4-5436-4f69-93f6-c1c8a57636d6.png">
