### PR TITLE
Fix #329

### DIFF
--- a/Xcodes/Backend/DateFormatter+.swift
+++ b/Xcodes/Backend/DateFormatter+.swift
@@ -6,6 +6,7 @@ extension DateFormatter {
         let formatter = DateFormatter()
         formatter.dateFormat = "MM/dd/yy HH:mm"
         formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.calendar = .init(identifier: .iso8601)
         return formatter
     }()
 


### PR DESCRIPTION
In some time zones, date parsing of the xcodes releases json is broken since it comes across a datetime that didn't exist in that timezone due to the effects of DST.
This pull request tries fixing it as per https://stackoverflow.com/a/71415385/