### PR TITLE
Remove forced uppercase in list view

### DIFF
--- a/Xcodes/Frontend/XcodeList/XcodeListViewRow.swift
+++ b/Xcodes/Frontend/XcodeList/XcodeListViewRow.swift
@@ -113,12 +113,10 @@ struct XcodeListViewRow: View {
         switch xcode.installState {
         case .installed:
             Button("Open") { appState.open(xcode: xcode) }
-                .textCase(.uppercase)
                 .buttonStyle(AppStoreButtonStyle(primary: true, highlighted: selected))
                 .help("OpenDescription")
         case .notInstalled:
             InstallButton(xcode: xcode)
-                .textCase(.uppercase)
                 .buttonStyle(AppStoreButtonStyle(primary: false, highlighted: false))
         case let .installing(installationStep):
             InstallationStepRowView(


### PR DESCRIPTION
All of the other buttons throughout the app use title casing so this change removes the forced uppercase for the `INSTALL` and `OPEN` buttons in the Xcode List View for visual consistency.

If there is a reason why the text is specifically all caps for this view I can close this PR but IMO the aesthetics are better with title casing.