### PR TITLE
Remove labels from filter button on toolbar

### DIFF
--- a/Xcodes/Frontend/XcodeList/MainToolbar.swift
+++ b/Xcodes/Frontend/XcodeList/MainToolbar.swift
@@ -33,17 +33,17 @@ struct MainToolbarModifier: ViewModifier {
                 switch category {
                 case .all:
                     Label("All", systemImage: "line.horizontal.3.decrease.circle")
+                        .help("FilterAvailableDescription")
                 case .release:
-                        Label("ReleaseOnly", systemImage: "line.horizontal.3.decrease.circle.fill")
-                            .labelStyle(.trailingIcon)
-                            .foregroundColor(.accentColor)
+                    Label("ReleaseOnly", systemImage: "line.horizontal.3.decrease.circle.fill")
+                        .foregroundColor(.accentColor)
+                        .help("ReleaseOnly")
                 case .beta:
                     Label("BetaOnly", systemImage: "line.horizontal.3.decrease.circle.fill")
-                        .labelStyle(.trailingIcon)
                         .foregroundColor(.accentColor)
+                        .help("BetaOnly")
                 }
             }
-            .help("FilterAvailableDescription")
 
             Button(action: {
                 isInstalledOnly.toggle()


### PR DESCRIPTION
This is related to #498, #550, #572.

With the default width of the sidebar, clicking the filter button on the toolbar will make the button disappear from the sidebar area, ending up in the rightmost corner:
![image](https://github.com/XcodesOrg/XcodesApp/assets/7774491/bdbf28ce-4ee5-4857-be89-1cb54bfee361)
![image](https://github.com/XcodesOrg/XcodesApp/assets/7774491/52a9534c-f45b-4ff0-9a8f-2f0832327f17)

Technically, it works as intended, but it's very confusing from the perspective of users: it looks like the buttons just disappear. Dragging the sidebar to make it wider can reveal the buttons, but it's not intuitive. Actually, I got stuck here for a few days, trying to figure out where my beta versions went.

I think we might avoid the overflow entirely, and I tried some different approaches like using abbreviations instead of full text such as "Release only," but the overflow still happens and does not look good:
![image](https://github.com/XcodesOrg/XcodesApp/assets/7774491/adc07f05-cebd-4933-a669-e3fd5baf7044)

Finally, I found that completely removing the labels could be the most ideal solution. A filled, highlighted button with floating help text could be intuitive enough and won't break the consistency of the UI:
![image](https://github.com/XcodesOrg/XcodesApp/assets/7774491/d329a7d7-bb33-42ef-99de-3090eadfa616)
![image](https://github.com/XcodesOrg/XcodesApp/assets/7774491/14d5821c-9038-4b36-950f-c9a0c45a3978)

I hope this change improves the user experience and keeps the UI clean and functional.