### PR TITLE
chore: add max sidebar width

### DIFF
--- a/Xcodes/Frontend/Common/NavigationSplitViewWrapper.swift
+++ b/Xcodes/Frontend/Common/NavigationSplitViewWrapper.swift
@@ -23,7 +23,7 @@ struct NavigationSplitViewWrapper<Sidebar, Detail>: View where Sidebar: View, De
         NavigationSplitView {
             if #available(macOS 14, *) {
                 sidebar
-                    .navigationSplitViewColumnWidth(min: 290, ideal: 290)
+                    .navigationSplitViewColumnWidth(min: 290, ideal: 290, max: 700)
             } else {
                 sidebar
             }


### PR DESCRIPTION
having it expandable to infinity is a bit of an issue if you somehow accidentally expand it full width of the window, though this issue does not happen when you have an Xcode version selected.

#

<img width="1174" alt="image" src="https://github.com/user-attachments/assets/e19c579d-5185-4456-a3d4-645ba240912f">

