### PR TITLE
Update zh_Hans translations and more.

### DIFF
--- a/Xcodes/Resources/Localizable.xcstrings
+++ b/Xcodes/Resources/Localizable.xcstrings
@@ -4783,7 +4783,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : ""
+            "value" : "Apple芯片"
           }
         },
         "zh-Hant" : {
@@ -5055,7 +5055,14 @@
       }
     },
     "Architecture" : {
-
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "架构"
+          }
+        }
+      }
     },
     "Authenticating" : {
       "extractionState" : "manual",
@@ -5964,7 +5971,14 @@
       }
     },
     "Category" : {
-
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "类别"
+          }
+        }
+      }
     },
     "Change" : {
       "localizations" : {
@@ -11371,7 +11385,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Install Apple Silicon"
+            "value" : "安装Apple芯片版本"
           }
         },
         "zh-Hant" : {
@@ -11495,7 +11509,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Install Universal"
+            "value" : "安装通用版本"
           }
         },
         "zh-Hant" : {
@@ -14127,7 +14141,14 @@
       }
     },
     "Installed Only" : {
-
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仅已安装"
+          }
+        }
+      }
     },
     "InstallHelper" : {
       "localizations" : {
@@ -23811,7 +23832,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Universal"
+            "value" : "通用"
           }
         },
         "zh-Hant" : {

--- a/Xcodes/XcodesKit/Sources/XcodesKit/Models/XcodeReleases/Architecture.swift
+++ b/Xcodes/XcodesKit/Sources/XcodesKit/Models/XcodeReleases/Architecture.swift
@@ -19,9 +19,9 @@ public enum Architecture: String, Codable, Equatable, Hashable, Identifiable, Ca
     public var displayString: String {
         switch self {
         case .arm64:
-            return "Apple Silicon"
+            return localizeString("Apple Silicon")
         case .x86_64:
-            return "Intel"
+            return localizeString("Intel")
         }
     }
     
@@ -44,9 +44,9 @@ public enum ArchitectureVariant: String, Codable, Equatable, Hashable, Identifia
     public var displayString: String {
         switch self {
         case .appleSilicon:
-            return "Apple Silicon"
+            return localizeString("Apple Silicon")
         case .universal:
-            return "Universal"
+            return localizeString("Universal")
         }
     }
     


### PR DESCRIPTION
zh_Hans localization.

Universal -> 通用
Apple Silicon -> Apple芯片
Architecture -> 架构
Category -> 类别
Install Apple Silicon -> 安装Apple芯片版本
Install Universal -> 安装通用版本
Installed Only -> 仅已安装

Updated Architecture.swift to allow showing architectures in localized strings for PlatformView.