### PR TITLE
fix: improve paste support for PIN code input fields

### DIFF
--- a/Xcodes/Frontend/SignIn/PinCodeTextView.swift
+++ b/Xcodes/Frontend/SignIn/PinCodeTextView.swift
@@ -149,6 +149,34 @@ class PinCodeTextView: NSControl, NSTextFieldDelegate {
         
         let newFieldText = field.stringValue
         
+        // Handle pasting multiple characters (e.g., pasting "123456" from clipboard)
+        if newFieldText.count > 1 {
+            // Filter to alphanumeric characters only
+            let validCharacters = newFieldText.filter { $0.isLetter || $0.isNumber }
+            
+            // Always start from the first field and clear previous content
+            var newCode = Array(repeating: Character?.none, count: numberOfDigits)
+            for (offset, character) in validCharacters.enumerated() {
+                if offset < numberOfDigits {
+                    newCode[offset] = character
+                }
+            }
+            
+            // Update all fields at once to avoid triggering didSet multiple times
+            code = newCode
+            
+            // Move focus to next empty field or the last field if all are filled
+            let nextEmptyIndex = code.firstIndex(where: { $0 == nil }) ?? numberOfDigits - 1
+            if nextEmptyIndex < characterViews.count {
+                window?.makeFirstResponder(characterViews[nextEmptyIndex])
+            } else {
+                resignFirstResponder()
+            }
+            
+            return
+        }
+        
+        // Handle single character input
         let lastCharacter: Character?
         if newFieldText.isEmpty {
             lastCharacter = nil


### PR DESCRIPTION
## Description
Improves the paste functionality for PIN code input fields used in SMS and 2FA authentication flows.

## Problem
When pasting a 6-digit verification code like "123456" into the PIN code input fields, only the last digit ("6") would appear in the first field. The other digits were lost.

## Solution
- Add detection for multi-character paste operations
- Filter pasted content to alphanumeric characters only
- Always start filling from the first field when pasting
- Optimize performance by updating all fields at once
- Support both numeric and alphanumeric codes (e.g., 123456, A1B2C3)

## Impact
This improvement benefits both:
- **SignInSMSView** - SMS verification code input
- **SignIn2FAView** - 2FA device verification code input

Both views share the same `PinCodeTextField` component, so the fix applies automatically to both flows.

## Testing
Tested with:
- ✅ Pasting 6-digit numeric codes (123456)
- ✅ Pasting with cursor in different positions (always fills from first field)
- ✅ Pasting codes with special characters (auto-filtered to alphanumeric only)
- ✅ Manual single-character input (unchanged behavior)

## Checklist
- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] No new warnings or errors introduced
- [x] Changes tested with real authentication flow