### PR TITLE
Fix: Install Apple Silicon shows Universal as Installing

### DIFF
--- a/Xcodes/Backend/AppState+Install.swift
+++ b/Xcodes/Backend/AppState+Install.swift
@@ -104,7 +104,7 @@ extension AppState {
     private func downloadXcode(availableXcode: AvailableXcode, downloader: Downloader) -> AnyPublisher<(AvailableXcode, URL), Error> {
             self.downloadOrUseExistingArchive(for: availableXcode, downloader: downloader, progressChanged: { [unowned self] progress in
                 DispatchQueue.main.async {
-                    self.setInstallationStep(of: availableXcode.version, to: .downloading(progress: progress))
+                    self.setInstallationStep(of: availableXcode.xcodeID, to: .downloading(progress: progress))
                     self.overallProgress.addChild(progress, withPendingUnitCount: AppState.totalProgressUnits - AppState.unxipProgressWeight)
                 }
             })
@@ -203,9 +203,9 @@ extension AppState {
                     }
                     .flatMap { installedXcode -> AnyPublisher<InstalledXcode, Error> in
                         do {
-                            self.setInstallationStep(of: availableXcode.version, to: .trashingArchive)
+                            self.setInstallationStep(of: availableXcode.xcodeID, to: .trashingArchive)
                             try Current.files.trashItem(at: archiveURL)
-                            self.setInstallationStep(of: availableXcode.version, to: .checkingSecurity)
+                            self.setInstallationStep(of: availableXcode.xcodeID, to: .checkingSecurity)
                             
                             return self.verifySecurityAssessment(of: installedXcode)
                                 .combineLatest(self.verifySigningCertificate(of: installedXcode.path.url))
@@ -217,7 +217,7 @@ extension AppState {
                         }
                     }
                     .flatMap { installedXcode -> AnyPublisher<InstalledXcode, Error> in
-                        self.setInstallationStep(of: availableXcode.version, to: .finishing)
+                        self.setInstallationStep(of: availableXcode.xcodeID, to: .finishing)
 
                         return self.performPostInstallSteps(for: installedXcode)
                             .map { installedXcode }
@@ -249,7 +249,7 @@ extension AppState {
     }
 
     func unarchiveAndMoveXIP(availableXcode: AvailableXcode, at source: URL, to destination: URL) -> AnyPublisher<URL, Swift.Error> {
-        self.setInstallationStep(of: availableXcode.version, to: .unarchiving)
+        self.setInstallationStep(of: availableXcode.xcodeID, to: .unarchiving)
         
         return unxipOrUnxipExperiment(source)
             .catch { error -> AnyPublisher<ProcessOutput, Swift.Error> in
@@ -267,7 +267,7 @@ extension AppState {
                     .eraseToAnyPublisher()
             }
         .tryMap { output -> URL in
-            self.setInstallationStep(of: availableXcode.version, to: .moving(destination: destination.path))
+            self.setInstallationStep(of: availableXcode.xcodeID, to: .moving(destination: destination.path))
 
             let xcodeURL = source.deletingLastPathComponent().appendingPathComponent("Xcode.app")
             let xcodeBetaURL = source.deletingLastPathComponent().appendingPathComponent("Xcode-beta.app")
@@ -496,9 +496,9 @@ extension AppState {
     
     // MARK: - 
     
-    func setInstallationStep(of version: Version, to step: XcodeInstallationStep) {
+    func setInstallationStep(of xcodeID: XcodeID, to step: XcodeInstallationStep) {
         DispatchQueue.main.async {
-            guard let index = self.allXcodes.firstIndex(where: { $0.version.isEquivalent(to: version) }) else { return }
+            guard let index = self.allXcodes.firstIndex(where: { $0.id == xcodeID }) else { return }
             self.allXcodes[index].installState = .installing(step)
             
             let xcode = self.allXcodes[index]

--- a/Xcodes/Backend/AppState.swift
+++ b/Xcodes/Backend/AppState.swift
@@ -557,7 +557,7 @@ class AppState: ObservableObject {
         installationPublishers[id] = signInIfNeeded()
             .handleEvents(
                 receiveSubscription: { [unowned self] _ in
-                    self.setInstallationStep(of: availableXcode.version, to: .authenticating)
+                    self.setInstallationStep(of: availableXcode.xcodeID, to: .authenticating)
                 }
             )
             .flatMap { [unowned self] in


### PR DESCRIPTION
## Summary
When clicking 'Install Apple Silicon', the UI incorrectly shows the Universal version as 'Installing' instead of the Apple Silicon version.

## Root Cause
`setInstallationStep` used `version.isEquivalent()` which doesn't consider architectures. When both Universal and Apple Silicon versions exist with the same Xcode version, the first one found (Universal) was marked as installing.

```swift
// Before: Uses version equivalence (ignores architectures)
func setInstallationStep(of version: Version, to step: XcodeInstallationStep) {
    guard let index = self.allXcodes.firstIndex(where: { $0.version.isEquivalent(to: version) }) else { return }
    // ...
}
```

## Fix
Changed `setInstallationStep` to accept `XcodeID` instead of `Version`, enabling exact matching including architectures:

```swift
// After: Uses XcodeID equality (includes architectures)
func setInstallationStep(of xcodeID: XcodeID, to step: XcodeInstallationStep) {
    guard let index = self.allXcodes.firstIndex(where: { $0.id == xcodeID }) else { return }
    // ...
}
```

## Testing
1. Filter list to show only Apple Silicon builds
2. Select an Xcode version with both Universal and Apple Silicon variants
3. Click 'Install Apple Silicon'
4. Verify the Apple Silicon row shows as 'Installing', not the Universal row

Fixes #776, #777, #782