### PR TITLE
Fix incorrect URL detection in SwiftUI Text

### DIFF
--- a/Xcodes/Resources/Localizable.xcstrings
+++ b/Xcodes/Resources/Localizable.xcstrings
@@ -9507,13 +9507,13 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "[@_saagarjha](https://twitter.com/_saagarjha) さんの方法で、一部のシステムで Unxip の速度が最大70%向上します。\n\n方法の詳細については、 unxipのリポジトリ (https://github.com/saagarjha/unxip)をご覧ください。"
+            "value" : "[@_saagarjha](https://twitter.com/_saagarjha) さんの方法で、一部のシステムで Unxip の速度が最大70%向上します。\n\n方法の詳細については、 unxipのリポジトリ (https://github.com/saagarjha/unxip) をご覧ください。"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "[@_saagarjha](https://twitter.com/_saagarjha)님 덕분에 이 실험 기능을 이용하면 일부 시스템에서 압축 해제 속도를 최대 70%까지 향상시킬 수 있습니다.\n\n이를 수행하는 방법에 대한 자세한 내용은 unxip 저장소 (https://github.com/saagarjha/unxip)에서 확인할 수 있습니다."
+            "value" : "[@_saagarjha](https://twitter.com/_saagarjha)님 덕분에 이 실험 기능을 이용하면 일부 시스템에서 압축 해제 속도를 최대 70%까지 향상시킬 수 있습니다.\n\n이를 수행하는 방법에 대한 자세한 내용은 unxip 저장소 (https://github.com/saagarjha/unxip) 에서 확인할 수 있습니다."
           }
         },
         "nl" : {


### PR DESCRIPTION
This issue occurred only in the Japanese and Korean localized versions.

In those translations, the URL was written without whitespace before the following text, causing SwiftUI's automatic URL detection to incorrectly include trailing characters (such as the closing parenthesis and subsequent text) as part of the link.

<img width="460" height="179" alt="image" src="https://github.com/user-attachments/assets/54144437-112a-45a7-b93d-0cbd3e3b8af6" />


As a result, the generated URL became invalid and led to a 404 error.

This PR fixes the issue by correcting the Japanese and Korean localized strings to ensure the URL is properly recognized and navigates to the intended page.

No changes were made to application logic or other localizations.