### PR TITLE
Fix: macOS 27 beta launch crash

### DIFF
--- a/Xcodes/Backend/AppState+Install.swift
+++ b/Xcodes/Backend/AppState+Install.swift
@@ -77,13 +77,15 @@ extension AppState {
     }
 
     private func getXcodeArchiveAsync(_ installationType: InstallationType, downloader: Downloader) async throws -> (AvailableXcode, URL) {
+        let installedXcodes = await updateInstalledXcodesAsync(recomposeAllXcodes: false)
+
         switch installationType {
         case .version(let availableXcode):
             let resolution = try mapInstallResolutionError {
                 try XcodeInstallResolutionService().resolve(
                     .availableXcode(availableXcode),
                     availableXcodes: [],
-                    installedXcodes: Current.files.installedXcodes(Path.installDirectory),
+                    installedXcodes: installedXcodes,
                     willInstall: true
                 )
             }

--- a/Xcodes/Backend/AppState+Update.swift
+++ b/Xcodes/Backend/AppState+Update.swift
@@ -26,6 +26,7 @@ extension AppState {
                         updateTaskID = nil
                     }
                 }
+                await self.updateInstalledXcodesAsync()
                 await self.updateSelectedXcodePathAsync()
             }
             updateTask = task
@@ -49,6 +50,7 @@ extension AppState {
                 }
             }
             do {
+                await self.updateInstalledXcodesAsync()
                 await self.updateSelectedXcodePathAsync()
                 let xcodes = try await self.updateAvailableXcodes(from: self.dataSource)
                 try Task.checkCancellation()

--- a/Xcodes/Backend/AppState.swift
+++ b/Xcodes/Backend/AppState.swift
@@ -48,7 +48,7 @@ class AppState: ObservableObject {
             }
             updateAllXcodes(
                 availableXcodes: newValue,
-                installedXcodes: Current.files.installedXcodes(Path.installDirectory),
+                installedXcodes: installedXcodes,
                 selectedXcodePath: selectedXcodePath
             )
         }
@@ -61,11 +61,12 @@ class AppState: ObservableObject {
         willSet {
             updateAllXcodes(
                 availableXcodes: availableXcodes,
-                installedXcodes: Current.files.installedXcodes(Path.installDirectory),
+                installedXcodes: installedXcodes,
                 selectedXcodePath: newValue
             )
         }
     }
+    private var installedXcodes: [InstalledXcode] = []
     @Published var updateTask: Task<Void, Never>?
     var updateTaskID: UUID?
     var isUpdating: Bool { updateTask != nil }
@@ -228,6 +229,9 @@ class AppState: ObservableObject {
         guard !isTesting else { return }
         try? loadCachedAvailableXcodes()
         try? loadCacheDownloadableRuntimes()
+        Task { @MainActor in
+            await updateInstalledXcodesAsync()
+        }
         helperStatusTask = Task { @MainActor in
             await checkIfHelperIsInstalled()
             helperStatusTask = nil
@@ -855,6 +859,24 @@ class AppState: ObservableObject {
         }
     }
 
+    @discardableResult
+    func updateInstalledXcodesAsync(recomposeAllXcodes: Bool = true) async -> [InstalledXcode] {
+        let installDirectory = Path.installDirectory
+        let files = Current.files
+        let installedXcodes = await Task.detached(priority: .userInitiated) {
+            files.installedXcodes(installDirectory)
+        }.value
+
+        self.installedXcodes = installedXcodes
+        if recomposeAllXcodes {
+            updateAllXcodes(
+                availableXcodes: availableXcodes,
+                installedXcodes: installedXcodes,
+                selectedXcodePath: selectedXcodePath
+            )
+        }
+        return installedXcodes
+    }
 
     // MARK: - Private
 


### PR DESCRIPTION
Issue: `AppState.init` loads cached available Xcodes, which assigns `availableXcodes`. That observer was doing installed-Xcode discovery synchronously on the main thread. On macOS 27 beta, that blocks inside `waitUntilExit()` while SwiftUI/AttributeGraph is creating `@StateObject AppState`, causing the launch crash.

#815

Fix: remove installed-Xcode discovery from the `availableXcodes` / `selectedXcodePath` observers. They now use cached installed-Xcode state only. Installed Xcodes are refreshed asynchronously after launch and before update/install resolution; install resolution refreshes without recomposing `allXcodes` so progress state is preserved.