### PR TITLE
Fix outdated Homebrew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ v3.X - requires macOS 13 - architecture variants and updated icon.
 Developer ID-signed and notarized release builds are available on Homebrew. These don't require Xcode to already be installed in order to use.
 
 ```sh
-brew install --cask xcodes
+brew install --cask xcodes-app
 ```
 
 ### Manually install


### PR DESCRIPTION
The cask name was renamed from "xcodes" to "xcodes-app": https://github.com/Homebrew/homebrew-cask/commit/d20f5f8baba92c739829d9798702c3aed2c718e7